### PR TITLE
fix:se elimina atributo de auto click ya que al ingresar al recibo se…

### DIFF
--- a/payco_whmcs/modules/gateways/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco.php
@@ -148,7 +148,6 @@ function epayco_link($params){
                 data-epayco-address-billing="%s"
                 data-epayco-extra1="%s"
                 data-epayco-extra2="%s"
-                data-epayco-autoclick="true"
                 >
             </script>
             


### PR DESCRIPTION
… abre automáticamente el checkout de ePayco antes de darle click al botón de Pagar ahora