### PR TITLE
Fix:  Evitar pago duplicado, sanear nombre y descripción del pedido, ocultar opción moneda en configuración, ver errores del checkout en la tienda

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 
 ## Versiones
+* [ePayco plugin WHMCS v8.3.0](https://github.com/epayco/Plugin_ePayco_WHMCS/releases/tag/v8.3.0).
 * [ePayco plugin WHMCS v8.2.2](https://github.com/epayco/Plugin_ePayco_WHMCS/releases/tag/v8.2.2).
 * [ePayco plugin WHMCS v8.2.1](https://github.com/epayco/Plugin_ePayco_WHMCS/releases/tag/v8.2.1).
 * [ePayco plugin WHMCS v8.2.0](https://github.com/epayco/Plugin_ePayco_WHMCS/releases/tag/v8.2.0).

--- a/payco_whmcs/modules/gateways/callback/epayco.php
+++ b/payco_whmcs/modules/gateways/callback/epayco.php
@@ -22,7 +22,7 @@ if($_GET['ref_payco'] === 'undefined'){
 }
 $obj = new EpaycoConfig("Epayco",$gatewayModule);
 if(!empty($_GET['ref_payco'])){
-    $responseData = @file_get_contents('https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco']);
+    $responseData = @file_get_contents('https://secure.epayco.co/validation/v1/reference/'.$_GET['ref_payco']);
     if($responseData === false){
         logTransaction($gatewayParams['name'], $_GET, 'Ocurrio un error al intentar validar la referencia');
         header("Location: ".$gatewayParams['systemurl']);

--- a/payco_whmcs/modules/gateways/callback/epayco.php
+++ b/payco_whmcs/modules/gateways/callback/epayco.php
@@ -1,4 +1,4 @@
-<?php
+ <?php
 include "../../../init.php";
 include ROOTDIR . "/includes/functions.php";
 include ROOTDIR . "/includes/gatewayfunctions.php";
@@ -22,7 +22,7 @@ if($_GET['ref_payco'] === 'undefined'){
 }
 $obj = new EpaycoConfig("Epayco",$gatewayModule);
 if(!empty($_GET['ref_payco'])){
-    $responseData = @file_get_contents('https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco']);
+    $responseData = @file_get_contents('https://secure.epayco.co/validation/v1/reference/'.$_GET['ref_payco']);
     if($responseData === false){
         logTransaction($gatewayParams['name'], $_GET, 'Ocurrio un error al intentar validar la referencia');
         header("Location: ".$gatewayParams['systemurl']);

--- a/payco_whmcs/modules/gateways/callback/epayco.php
+++ b/payco_whmcs/modules/gateways/callback/epayco.php
@@ -22,7 +22,7 @@ if($_GET['ref_payco'] === 'undefined'){
 }
 $obj = new EpaycoConfig("Epayco",$gatewayModule);
 if(!empty($_GET['ref_payco'])){
-    $responseData = @file_get_contents('https://secure.epayco.co/validation/v1/reference/'.$_GET['ref_payco']);
+    $responseData = @file_get_contents('https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco']);
     if($responseData === false){
         logTransaction($gatewayParams['name'], $_GET, 'Ocurrio un error al intentar validar la referencia');
         header("Location: ".$gatewayParams['systemurl']);

--- a/payco_whmcs/modules/gateways/callback/epayco.php
+++ b/payco_whmcs/modules/gateways/callback/epayco.php
@@ -22,7 +22,7 @@ if($_GET['ref_payco'] === 'undefined'){
 }
 $obj = new EpaycoConfig("Epayco",$gatewayModule);
 if(!empty($_GET['ref_payco'])){
-    $responseData = @file_get_contents('https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco']);
+    $responseData = @file_get_contents('https://secure.epayco.co/validation/v1/reference/'.$_GET['ref_payco']);
     if($responseData === false){
         logTransaction($gatewayParams['name'], $_GET, 'Ocurrio un error al intentar validar la referencia');
         header("Location: ".$gatewayParams['systemurl']);
@@ -43,5 +43,3 @@ if(!empty($_GET['ref_payco'])){
         exit("Callback completo: " . var_export(200,1));
     }
 }
-
-

--- a/payco_whmcs/modules/gateways/callback/epayco.php
+++ b/payco_whmcs/modules/gateways/callback/epayco.php
@@ -21,18 +21,29 @@ if($_GET['ref_payco'] === 'undefined'){
     $returnUrl = $gatewayParams['systemurl'];
 }
 $obj = new EpaycoConfig("Epayco",$gatewayModule);
+
+
 if(!empty($_GET['ref_payco'])){
-    $responseData = @file_get_contents('https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco']);
+    $url = 'https://eks-checkout-service.epayco.io/validation/v1/reference/'.$_GET['ref_payco'];
+    $responseData = @file_get_contents($url);
     if($responseData === false){
+        echo "<pre>ERROR: No se pudo obtener respuesta de la API</pre>";
         logTransaction($gatewayParams['name'], $_GET, 'Ocurrio un error al intentar validar la referencia');
         header("Location: ".$gatewayParams['systemurl']);
     }
     $jsonData = @json_decode($responseData, true);
+   
     $validationData = $jsonData['data'];
+  
     $obj->crearTablaCustomTransacciones();
+    echo "<pre>Procesando confirmación...</pre>";
     $respuesta = $obj->epaycoConfirmation($GATEWAY, $validationData);
+   
     $returnUrl = $gatewayParams['systemurl'].'modules/gateways/epayco/response.php';
-    header("Location: ".$returnUrl.'?ref_payco='.$_GET['ref_payco']);
+    $fullRedirectUrl = $returnUrl.'?ref_payco='.$_GET['ref_payco'];
+    echo "<pre>Redirigiendo...</pre>";
+    echo "<script>setTimeout(function(){ window.location.href = '".$fullRedirectUrl."'; }, 3000);</script>";
+    header("Location: ".$fullRedirectUrl);
 }else {
     if (!empty(trim($_REQUEST['x_ref_payco']))) {
         $validationData = $_REQUEST;

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -304,7 +304,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://epayco-checkout-testing.s3.us-east-1.amazonaws.com/checkout.preprod.js">
+                src="https://checkout.epayco.co/checkout.js">
             </script>
             <script>
             const publicKey = "%s";
@@ -378,7 +378,7 @@ class EpaycoConfig
                         "Authorization": "Bearer " + bearerToken
                     };
                     var payment =   function (){
-                        return  fetch("https://eks-apify-service.epayco.io/payment/session/create", {
+                        return  fetch("https://apify.epayco.co/payment/session/create", {
                             method: "POST",
                             body: JSON.stringify(info),
                             headers
@@ -488,7 +488,7 @@ class EpaycoConfig
     {        
        $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
         return $this->makeRequest($gateway,[], $url, "Bearer ".$bearer_token);
     }
     function makeRequest($gateway,$data,$url,$bearerToken = false){
@@ -783,7 +783,7 @@ class EpaycoConfig
         return $countries;
     }
     function ePaycoToken($gateway){
-       $url = "https://eks-apify-service.epayco.io/login";
+       $url = "https://apify.epayco.co/login";
        $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -813,7 +813,7 @@ class EpaycoConfig
     }
     function epaycoSessionPayment($gateway,$data){
         $bearer_token = $this->ePaycoToken($gateway);
-        $url = "https://eks-apify-service.epayco.io/payment/session/create";
+        $url = "https://apify.epayco.co/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer ".$bearer_token);
     }
     function getCustomerIp(){

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -26,22 +26,10 @@ class EpaycoConfig
                     $table->dateTime("momento");
                     $table->string("gateway");
                     $table->string("refPayco");
-                    $table->integer("reintentos_count")->default(0);
                 });
                 return true;
             } catch (\Exception $ex) {
                 throw new Exception("No se pudo crear la tabla de transacciones: " . $ex->getMessage());
-            }
-        } else {
-            // Agregar columna si no existe
-            if (!WHMCS\Database\Capsule::schema()->hasColumn($nombreTabla, 'reintentos_count')) {
-                try {
-                    WHMCS\Database\Capsule::schema()->table($nombreTabla, function ($table) {
-                        $table->integer('reintentos_count')->default(0);
-                    });
-                } catch (\Exception $ex) {
-                    // Columna ya existe o error
-                }
             }
         }
         return false;

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -447,10 +447,10 @@ class EpaycoConfig
     function epaycoConfirmation($gatewayOBJ, $informe, $confirmation = false)
     {
         $gatewayModule = $this->modulo;
-        //$informes = json_decode(file_get_contents("php://input"), true);
-        $informe_cobro = $informe['x_extra1'];
+        //$reports = json_decode(file_get_contents("php://input"), true);
+        $reportNumber = $informe['x_extra1'];
         $email = $gatewayOBJ["email"];
-        //$modoProcesamientoPorColas = $gatewayOBJ["bh_modocolaprocesamiento"] == "on";
+        //$processingModePerQueues = $gatewayOBJ["bh_modocolaprocesamiento"] == "on";
         $admin = $gatewayOBJ["useradmin"];
         if (!empty($admin)) {
             $adminUsername = $gatewayOBJ["useradmin"];
@@ -466,21 +466,21 @@ class EpaycoConfig
             //mail($email, $informe_id . " - Start", print_r($informe, true));
         }
         $command = "GetInvoice";
-        $postData = array("invoiceid" => (string)$informe_cobro);
-        $arr_transacciones = localAPI($command, $postData, $adminUsername);
-        $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $informe['x_extra1'])->get();
+        $postData = array("invoiceid" => (string)$reportNumber);
+        $transactions = localAPI($command, $postData, $adminUsername);
+        $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $informe['x_extra1'])->get();
 
-        if ($arr_transacciones["result"] !== 'success' || count($resultado) == 0) {
-            Capsule::table("bapp_epayco")->insert(array("transaccion" => $informe_cobro, "momento" => date("Y-m-d H:i:s"), "gateway" => $gatewayModule, "refPayco" => $informe['x_ref_payco']));
+        if ($transactions["result"] !== 'success' || count($result) == 0) {
+            Capsule::table("bapp_epayco")->insert(array("transaccion" => $reportNumber, "momento" => date("Y-m-d H:i:s"), "gateway" => $gatewayModule, "refPayco" => $informe['x_ref_payco']));
         }
 
         return $this->callbackEpayco($informe, $confirmation);
     }
-    function getPaymentEpayco($gateway, $transaccion)
+    function getPaymentEpayco($gateway, $transaction)
     {
         $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaction . "&&public_key=" . $publicKey;
         return $this->makeRequest($gateway, [], $url, "Bearer " . $bearer_token);
     }
     function makeRequest($gateway, $data, $url, $bearerToken = false)
@@ -611,7 +611,7 @@ class EpaycoConfig
 
             return $data;
         } catch (\Exception $ex) {
-            throw new Exception("No se pudorealizar la accion: " . $ex->getMessage());
+            throw new Exception("Action could not be performed: " . $ex->getMessage());
         }
     }
 
@@ -621,28 +621,28 @@ class EpaycoConfig
 
         if ($confirmation) {
             if (!empty($idtrans['x_extra1'])) {
-                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $idtrans['x_extra1'])->get();
-                $mp_id = $resultado[0]->id;
-                $mp_transaccion = $resultado[0]->transaccion;
-                $mp_momento = $resultado[0]->momento;
-                $mp_gateway = $resultado[0]->gateway;
-                $ref_payco = $resultado[0]->refPayco;
+                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $idtrans['x_extra1'])->get();
+                $mp_id = $result[0]->id;
+                $mp_transaction = $result[0]->transaccion;
+                $mp_moment = $result[0]->momento;
+                $mp_gateway = $result[0]->gateway;
+                $ref_payco = $result[0]->refPayco;
             } else {
-                $resultado = Capsule::table("bapp_epayco")->first();
-                $mp_id = $resultado->id;
-                $mp_transaccion = $resultado->transaccion;
-                $mp_momento = $resultado->momento;
-                $mp_gateway = $resultado->gateway;
-                $ref_payco = $resultado->refPayco;
+                $result = Capsule::table("bapp_epayco")->first();
+                $mp_id = $result->id;
+                $mp_transaction = $result->transaccion;
+                $mp_moment = $result->momento;
+                $mp_gateway = $result->gateway;
+                $ref_payco = $result->refPayco;
             }
         } else {
-            $mp_transaccion = $idtrans['x_extra1'];
+            $mp_transaction = $idtrans['x_extra1'];
             $mp_gateway = 'epayco';
             $ref_payco = $idtrans['x_ref_payco'];
         }
         $GATEWAY = getGatewayVariables($mp_gateway);
 
-        if (!empty($mp_transaccion)) {
+        if (!empty($mp_transaction)) {
 
             $admin = $GATEWAY["useradmin"];
             if (!empty($admin)) {
@@ -650,7 +650,7 @@ class EpaycoConfig
             }
 
             $command = "GetInvoice";
-            $postData = array("invoiceid" => $mp_transaccion);
+            $postData = array("invoiceid" => $mp_transaction);
             $invoice = localAPI($command, $postData, $adminUsername);
 
             if ($invoice["result"] == 'success') {
@@ -685,62 +685,80 @@ class EpaycoConfig
                 if (($signature == $validationData['x_signature'] || $validationData['x_signature'] == 'Authorized')  && $validation) {
                     switch ((int)$validationData['x_cod_response']) {
                         case 1: {
-                                echo "<pre style='background:green;color:white;'>DEBUG CASE 1 - ACEPTADA</pre>";
-                                var_dump("Entrando case 1");
+                                echo "<pre style='background:green;color:white;'>DEBUG CASE 1 - ACCEPTED</pre>";
+                                var_dump("Entering case 1");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
                                 $message = 'AcceptOrder';
                                 if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
-                                    // Descontar stock cuando el pago es aceptado
-                                    echo "<pre>DEBUG CASE 1: Procesando descuento de stock</pre>";
+                                    // Check if there were previous retry attempts
+                                    $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                     
-                                    $productInfo = array();
-                                    $productData = array();
+                                    // hadPreviousFails = true if: transaction exists AND momento='0000-00-00 00:00:00' (was marked as processed after failure)
+                                    // hadPreviousFails = false if: no transaction OR momento is not the special flag (direct payment)
+                                    $hadPreviousFails = ($result && $result->momento === '0000-00-00 00:00:00');
                                     
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
+                                    echo "<pre>DEBUG CASE 1: Previous failed attempts check</pre>";
+                                    var_dump("Had previous fails: " . ($hadPreviousFails ? "YES" : "NO"));
                                     
-                                    echo "<pre>DEBUG CASE 1: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    echo "<pre>DEBUG CASE 1: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
-                                    if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 1: Entrando al IF de productInfo no vacío</pre>";
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
-
-                                        echo "<pre>DEBUG CASE 1: Productos de DB</pre>";
-                                        var_dump($products);
-
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty - 1;
-                                        }
-
-                                        echo "<pre>DEBUG CASE 1: Product Data Array después de restar qty</pre>";
-                                        var_dump($productData);
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                    if ($hadPreviousFails) {
+                                        // There were previous failed attempts that we restored stock for
+                                        // WHMCS already discounted on first attempt, we restored for each failure
+                                        // Now we must discount again because payment succeeded
+                                        echo "<pre>DEBUG CASE 1: RETRY PAYMENT - Will discount stock (was restored by previous failures)</pre>";
+                                        
+                                        $productInfo = array();
+                                        $productData = array();
+                                        
+                                        $productsOrder = Capsule::table('tblinvoiceitems')
+                                            ->select('tblinvoiceitems.description')
+                                            ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                            ->where('tblinvoiceitems.type', '=', 'Hosting')
+                                            ->get();
+                                        
+                                        echo "<pre>DEBUG CASE 1: Products obtained</pre>";
+                                        var_dump($productsOrder);
+                                        
+                                        foreach ($productsOrder as $productOrder) {
+                                            $explodProduct = explode(' - ', $productOrder->description, 2);
+                                            $productInfo[] = $explodProduct[0];
                                         }
                                         
-                                        echo "<pre style='background:lightgreen;'>DEBUG CASE 1: Stock descontado exitosamente (1 unidad)</pre>";
+                                        echo "<pre>DEBUG CASE 1: Product Info Array</pre>";
+                                        var_dump($productInfo);
+                                        
+                                        if (!empty($productInfo)) {
+                                            echo "<pre>DEBUG CASE 1: Entering IF with non-empty productInfo</pre>";
+                                            $products = Capsule::table('tblproducts')
+                                                ->whereIn('name', $productInfo)
+                                                ->get(['name', 'qty'])
+                                                ->all();
+
+                                            echo "<pre>DEBUG CASE 1: Products from DB</pre>";
+                                            var_dump($products);
+
+                                            for ($i = 0; $i < count($products); $i++) {
+                                                $productData[$i]["name"] = $products[$i]->name;
+                                                $productData[$i]["qty"] =  $products[$i]->qty - 1;
+                                            }
+
+                                            echo "<pre>DEBUG CASE 1: Product Data Array after subtracting qty</pre>";
+                                            var_dump($productData);
+
+                                            for ($j = 0; $j < count($productData); $j++) {
+                                                Capsule::table('tblproducts')
+                                                    ->where('name', "=", $productData[$j]["name"])
+                                                    ->update(['qty' => $productData[$j]["qty"]]);
+                                            }
+                                            
+                                            echo "<pre style='background:lightgreen;'>DEBUG CASE 1: Stock discounted successfully (1 unit)</pre>";
+                                        } else {
+                                            echo "<pre>DEBUG CASE 1: ProductInfo is empty - NO PRODUCTS TO DISCOUNT STOCK</pre>";
+                                        }
                                     } else {
-                                        echo "<pre>DEBUG CASE 1: ProductInfo está vacío - NO HAY PRODUCTOS PARA DESCONTAR STOCK</pre>";
+                                        // Direct payment without previous failures - WHMCS already discounted stock
+                                        // Do NOT discount again
+                                        echo "<pre>DEBUG CASE 1: DIRECT PAYMENT - WHMCS already discounted stock, skipping stock adjustment</pre>";
                                     }
                                     
                                     addInvoicePayment(
@@ -750,7 +768,7 @@ class EpaycoConfig
                                         null,
                                         $GATEWAY['paymentmethod']
                                     );
-                                    logTransaction($GATEWAY['name'], $validationData, "Aceptada");
+                                    logTransaction($GATEWAY['name'], $validationData, "Accepted");
                                     $results = localAPI($message, $postData, $adminUsername);
                                     // Transaction is recorded in WHMCS (without duplicating payment)
                                     $command = "AddTransaction";
@@ -761,76 +779,22 @@ class EpaycoConfig
                                         "description" => "Pago Epayco - Referencia: " . $validationData['x_ref_payco']
                                     );
                                     $results = localAPI($command, $postData, $adminUsername);
-                                } else {
-                                    if ($invoice['status'] == 'Cancelled') {
-
-                                echo "<pre>DEBUG CASE 2 - RECHAZADA: Entrando al case 2.2</pre>";
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                var_dump("Validation Data x_extra1: " . $validationData['x_extra1']);
-                                var_dump("Validation Data x_extra2: " . $validationData['x_extra2']);
-                                        $productsOrder = Capsule::table('tblinvoiceitems')
-                                            ->select('tblinvoiceitems.description')
-                                            ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra2'])
-                                            ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                            ->get();
-                                        foreach ($productsOrder as $productOrder) {
-                                            $explodProduct = explode(' - ', $productOrder->description, 2);
-                                            $productInfo[] = $explodProduct[0];
-                                        }
-
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
-
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty - 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            $connection = Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-
-                                        $results = localAPI('PendingOrder', $postData, $adminUsername);
-                                        addInvoicePayment(
-                                            $invoice['invoiceid'],
-                                            $validationData['x_ref_payco'],
-                                            $invoice['total'],
-                                            null,
-                                            $GATEWAY['paymentmethod']
-                                        );
-                                        logTransaction($GATEWAY['name'], $validationData, "Aceptada");
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                        $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
-                                        // Transaction is recorded in WHMCS (without duplicating payment)
-                                        $command = "AddTransaction";
-                                        $postData = array(
-                                            "userid" => $invoice['userid'],
-                                            "transid" => $validationData['x_ref_payco'],
-                                            "amount" => $validationData['x_amount'],
-                                            "description" => "Pago Epayco - Referencia: " . $validationData['x_ref_payco']
-                                        );
-                                        $results = localAPI($command, $postData, $adminUsername);
-                                    }
                                 }
                             }
                             break;
                         case 2: {
-                                //rechazada - restaurar stock sin duplicar
-                                echo "<pre>DEBUG CASE 2 - RECHAZADA: Verificando duplicados</pre>";
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                var_dump("Transacción existente: " . ($resultado ? "SÍ" : "NO"));
+                                //rejected - restore stock without duplicating
+                                echo "<pre>DEBUG CASE 2 - REJECTED: Checking duplicates</pre>";
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                var_dump("Existing transaction: " . ($result ? "YES" : "NO"));
                                 
-                                // Verificar si ya fue procesada (momento = 0000-00-00 es la bandera)
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check if already processed (momento = 0000-00-00 is the flag)
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    echo "<pre>DEBUG: Procesando rechazada</pre>";
-                                    logTransaction($GATEWAY['name'], $validationData, "Rechazada");
+                                if ($result && !$alreadyProcessed) {
+                                    echo "<pre>DEBUG: Processing rejected</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Rejected");
 
                                     $productInfo = array();
                                     $productData = array();
@@ -881,29 +845,29 @@ class EpaycoConfig
                                         echo "<pre>DEBUG: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
                                     }
                                     
-                                    // Marcar como procesada (sin eliminar, para que no se reinserente)
-                                    echo "<pre>DEBUG: Marcando transacción como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed (without deleting, so it doesn't reinsert)
+                                    echo "<pre>DEBUG: Marking transaction as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:yellow;'>DEBUG CASE 2: Transacción YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:yellow;'>DEBUG CASE 2: Transaction ALREADY PROCESSED, ignoring</pre>";
                                 }
                                 
-                                $message = 'RechazadaPayment';
+                                $message = 'RejectedPayment';
                             }
                             break;
                         case 3: {
-                                echo "<pre style='background:orange;color:white;'>DEBUG CASE 3 - PENDIENTE</pre>";
-                                var_dump("Entrando case 3");
+                                echo "<pre style='background:orange;color:white;'>DEBUG CASE 3 - PENDING</pre>";
+                                var_dump("Entering case 3");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                // Verificar duplicados
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check for duplicates
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    //pendiente - restaurar stock
-                                    echo "<pre>DEBUG CASE 3: Procesando pendiente</pre>";
+                                if ($result && !$alreadyProcessed) {
+                                    //pending - restore stock
+                                    echo "<pre>DEBUG CASE 3: Processing pending</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -950,9 +914,9 @@ class EpaycoConfig
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
                                         
-                                        echo "<pre style='background:lightsalmon;'>DEBUG CASE 3: Stock actualizado exitosamente</pre>";
+                                        echo "<pre style='background:lightsalmon;'>DEBUG CASE 3: Stock updated successfully</pre>";
                                     } else {
-                                        echo "<pre>DEBUG CASE 3: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                        echo "<pre>DEBUG CASE 3: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -960,27 +924,27 @@ class EpaycoConfig
                                         $results = localAPI($message, $postData, $adminUsername);
                                     }
                                     
-                                    // Marcar como procesada
-                                    echo "<pre>DEBUG CASE 3: Marcando como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed
+                                    echo "<pre>DEBUG CASE 3: Marking as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:orange;'>DEBUG CASE 3: YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:orange;'>DEBUG CASE 3: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 4: {
-                                echo "<pre style='background:red;color:white;'>DEBUG CASE 4 - FALLIDA</pre>";
-                                var_dump("Entrando case 4");
+                                echo "<pre style='background:red;color:white;'>DEBUG CASE 4 - FAILED</pre>";
+                                var_dump("Entering case 4");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                // Verificar duplicados
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check for duplicates
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    //fallida - restaurar stock
-                                    echo "<pre>DEBUG CASE 4: Procesando fallida</pre>";
+                                if ($result && !$alreadyProcessed) {
+                                    //failed - restore stock
+                                    echo "<pre>DEBUG CASE 4: Processing failed</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1027,9 +991,9 @@ class EpaycoConfig
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
                                         
-                                        echo "<pre style='background:lightcoral;'>DEBUG CASE 4: Stock actualizado exitosamente</pre>";
+                                        echo "<pre style='background:lightcoral;'>DEBUG CASE 4: Stock updated successfully</pre>";
                                     } else {
-                                        echo "<pre>DEBUG CASE 4: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                        echo "<pre>DEBUG CASE 4: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1037,27 +1001,27 @@ class EpaycoConfig
                                         $results = localAPI($message, $postData, $adminUsername);
                                     }
                                     
-                                    // Marcar como procesada
-                                    echo "<pre>DEBUG CASE 4: Marcando como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed
+                                    echo "<pre>DEBUG CASE 4: Marking as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:red;'>DEBUG CASE 4: YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:red;'>DEBUG CASE 4: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 6: {
                                 echo "<pre style='background:purple;color:white;'>DEBUG CASE 6</pre>";
-                                var_dump("Entrando case 6");
+                                var_dump("Entering case 6");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                // Verificar duplicados
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check for duplicates
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    //pendiente - restaurar stock
-                                    echo "<pre>DEBUG CASE 6: Procesando</pre>";
+                                if ($result && !$alreadyProcessed) {
+                                    //pending - restore stock
+                                    echo "<pre>DEBUG CASE 6: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1104,9 +1068,9 @@ class EpaycoConfig
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
                                         
-                                        echo "<pre style='background:lightyellow;'>DEBUG CASE 6: Stock actualizado exitosamente</pre>";
+                                        echo "<pre style='background:lightyellow;'>DEBUG CASE 6: Stock updated successfully</pre>";
                                     } else {
-                                        echo "<pre>DEBUG CASE 6: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                        echo "<pre>DEBUG CASE 6: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1114,27 +1078,27 @@ class EpaycoConfig
                                         $results = localAPI($message, $postData, $adminUsername);
                                     }
                                     
-                                    // Marcar como procesada
-                                    echo "<pre>DEBUG CASE 6: Marcando como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed
+                                    echo "<pre>DEBUG CASE 6: Marking as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:purple;'>DEBUG CASE 6: YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:purple;'>DEBUG CASE 6: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 10: {
                                 echo "<pre style='background:navy;color:white;'>DEBUG CASE 10</pre>";
-                                var_dump("Entrando case 10");
+                                var_dump("Entering case 10");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                // Verificar duplicados
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check for duplicates
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    //pendiente - restaurar stock
-                                    echo "<pre>DEBUG CASE 10: Procesando</pre>";
+                                if ($result && !$alreadyProcessed) {
+                                    //pending - restore stock
+                                    echo "<pre>DEBUG CASE 10: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1181,9 +1145,9 @@ class EpaycoConfig
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
                                         
-                                        echo "<pre style='background:lightblue;'>DEBUG CASE 10: Stock actualizado exitosamente</pre>";
+                                        echo "<pre style='background:lightblue;'>DEBUG CASE 10: Stock updated successfully</pre>";
                                     } else {
-                                        echo "<pre>DEBUG CASE 10: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                        echo "<pre>DEBUG CASE 10: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1191,27 +1155,27 @@ class EpaycoConfig
                                         $results = localAPI($message, $postData, $adminUsername);
                                     }
                                     
-                                    // Marcar como procesada
-                                    echo "<pre>DEBUG CASE 10: Marcando como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed
+                                    echo "<pre>DEBUG CASE 10: Marking as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:navy;'>DEBUG CASE 10: YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:navy;'>DEBUG CASE 10: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 11: {
                                 echo "<pre style='background:teal;color:white;'>DEBUG CASE 11</pre>";
-                                var_dump("Entrando case 11");
+                                var_dump("Entering case 11");
                                 var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                // Verificar duplicados
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
-                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
-                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                // Check for duplicates
+                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
-                                if ($resultado && !$yaFueProcesada) {
-                                    //pendiente - restaurar stock
-                                    echo "<pre>DEBUG CASE 11: Procesando</pre>";
+                                if ($result && !$alreadyProcessed) {
+                                    //pending - restore stock
+                                    echo "<pre>DEBUG CASE 11: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1258,9 +1222,9 @@ class EpaycoConfig
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
                                         
-                                        echo "<pre style='background:lightseagreen;'>DEBUG CASE 11: Stock actualizado exitosamente</pre>";
+                                        echo "<pre style='background:lightseagreen;'>DEBUG CASE 11: Stock updated successfully</pre>";
                                     } else {
-                                        echo "<pre>DEBUG CASE 11: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                        echo "<pre>DEBUG CASE 11: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1268,11 +1232,11 @@ class EpaycoConfig
                                         $results = localAPI($message, $postData, $adminUsername);
                                     }
                                     
-                                    // Marcar como procesada
-                                    echo "<pre>DEBUG CASE 11: Marcando como procesada</pre>";
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                    // Mark as processed
+                                    echo "<pre>DEBUG CASE 11: Marking as processed</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
                                 } else {
-                                    echo "<pre style='background:teal;'>DEBUG CASE 11: YA PROCESADA, ignorando</pre>";
+                                    echo "<pre style='background:teal;'>DEBUG CASE 11: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
@@ -1282,8 +1246,8 @@ class EpaycoConfig
                 }
             } else {
                 $message = "UndefinedOrder";
-                //BORRAR PORQUE YA FUE INGRESADA LA TRANSACCION
-                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
+                //DELETE BECAUSE TRANSACTION WAS ALREADY ENTERED
+                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->delete();
             }
         }
         return $message;

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -639,19 +639,17 @@ class EpaycoConfig
 
     function handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, $logType = "Failure")
     {
-        // Verificar si ya fue procesado
+      
         $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
         $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
 
-        // Si no fue procesado, hacer todo
         if ($result && !$alreadyProcessed) {
-            // Registrar log
+       
             logTransaction($GATEWAY['name'], $validationData, $logType);
 
-            // Restaurar stock (llamar la función que creamos)
+          
             $this->restoreProductStock($validationData['x_extra1'], 1);
 
-            // Marcar como procesado
             Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
         }
     }
@@ -728,17 +726,13 @@ class EpaycoConfig
                         case 1: {
                                 $message = 'AcceptOrder';
                                 if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
-                                    // Check if there were previous retry attempts
                                     $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
 
-                                    // hadPreviousFails = true if: transaction exists AND momento='0000-00-00 00:00:00' (was marked as processed after failure)
-                                    // hadPreviousFails = false if: no transaction OR momento is not the special flag (direct payment)
+                                    // Check if transaction had previous failed attempts: momento='0000-00-00 00:00:00' marks processed failures
                                     $hadPreviousFails = ($result && $result->momento === '0000-00-00 00:00:00');
 
                                     if ($hadPreviousFails) {
-                                        // There were previous failed attempts that we restored stock for
-                                        // WHMCS already discounted on first attempt, we restored for each failure
-                                        // Now we must discount again because payment succeeded
+                                        // Discount stock again since payment succeeded after previous failures where we restored it
                                         $this->restoreProductStock($validationData['x_extra1'], -1);
                                     }
 
@@ -751,7 +745,7 @@ class EpaycoConfig
                                     );
                                     logTransaction($GATEWAY['name'], $validationData, "Accepted");
                                     $results = localAPI($message, $postData, $adminUsername);
-                                    // Transaction is recorded in WHMCS (without duplicating payment)
+                                  
                                     $command = "AddTransaction";
                                     $postData = array(
                                         "userid" => $invoice['userid'],

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -685,10 +685,6 @@ class EpaycoConfig
                 if (($signature == $validationData['x_signature'] || $validationData['x_signature'] == 'Authorized')  && $validation) {
                     switch ((int)$validationData['x_cod_response']) {
                         case 1: {
-                                echo "<pre style='background:green;color:white;'>DEBUG CASE 1 - ACCEPTED</pre>";
-                                var_dump("Entering case 1");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 $message = 'AcceptOrder';
                                 if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
                                     // Check if there were previous retry attempts
@@ -698,14 +694,10 @@ class EpaycoConfig
                                     // hadPreviousFails = false if: no transaction OR momento is not the special flag (direct payment)
                                     $hadPreviousFails = ($result && $result->momento === '0000-00-00 00:00:00');
                                     
-                                    echo "<pre>DEBUG CASE 1: Previous failed attempts check</pre>";
-                                    var_dump("Had previous fails: " . ($hadPreviousFails ? "YES" : "NO"));
-                                    
                                     if ($hadPreviousFails) {
                                         // There were previous failed attempts that we restored stock for
                                         // WHMCS already discounted on first attempt, we restored for each failure
                                         // Now we must discount again because payment succeeded
-                                        echo "<pre>DEBUG CASE 1: RETRY PAYMENT - Will discount stock (was restored by previous failures)</pre>";
                                         
                                         $productInfo = array();
                                         $productData = array();
@@ -716,49 +708,28 @@ class EpaycoConfig
                                             ->where('tblinvoiceitems.type', '=', 'Hosting')
                                             ->get();
                                         
-                                        echo "<pre>DEBUG CASE 1: Products obtained</pre>";
-                                        var_dump($productsOrder);
-                                        
                                         foreach ($productsOrder as $productOrder) {
                                             $explodProduct = explode(' - ', $productOrder->description, 2);
                                             $productInfo[] = $explodProduct[0];
                                         }
                                         
-                                        echo "<pre>DEBUG CASE 1: Product Info Array</pre>";
-                                        var_dump($productInfo);
-                                        
                                         if (!empty($productInfo)) {
-                                            echo "<pre>DEBUG CASE 1: Entering IF with non-empty productInfo</pre>";
                                             $products = Capsule::table('tblproducts')
                                                 ->whereIn('name', $productInfo)
                                                 ->get(['name', 'qty'])
                                                 ->all();
-
-                                            echo "<pre>DEBUG CASE 1: Products from DB</pre>";
-                                            var_dump($products);
 
                                             for ($i = 0; $i < count($products); $i++) {
                                                 $productData[$i]["name"] = $products[$i]->name;
                                                 $productData[$i]["qty"] =  $products[$i]->qty - 1;
                                             }
 
-                                            echo "<pre>DEBUG CASE 1: Product Data Array after subtracting qty</pre>";
-                                            var_dump($productData);
-
                                             for ($j = 0; $j < count($productData); $j++) {
                                                 Capsule::table('tblproducts')
                                                     ->where('name', "=", $productData[$j]["name"])
                                                     ->update(['qty' => $productData[$j]["qty"]]);
                                             }
-                                            
-                                            echo "<pre style='background:lightgreen;'>DEBUG CASE 1: Stock discounted successfully (1 unit)</pre>";
-                                        } else {
-                                            echo "<pre>DEBUG CASE 1: ProductInfo is empty - NO PRODUCTS TO DISCOUNT STOCK</pre>";
                                         }
-                                    } else {
-                                        // Direct payment without previous failures - WHMCS already discounted stock
-                                        // Do NOT discount again
-                                        echo "<pre>DEBUG CASE 1: DIRECT PAYMENT - WHMCS already discounted stock, skipping stock adjustment</pre>";
                                     }
                                     
                                     addInvoicePayment(
@@ -784,16 +755,12 @@ class EpaycoConfig
                             break;
                         case 2: {
                                 //rejected - restore stock without duplicating
-                                echo "<pre>DEBUG CASE 2 - REJECTED: Checking duplicates</pre>";
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                var_dump("Existing transaction: " . ($result ? "YES" : "NO"));
                                 
                                 // Check if already processed (momento = 0000-00-00 is the flag)
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
-                                    echo "<pre>DEBUG: Processing rejected</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Rejected");
 
                                     $productInfo = array();
@@ -805,69 +772,43 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightgreen;'>DEBUG: Stock actualizado exitosamente</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
                                     }
                                     
                                     // Mark as processed (without deleting, so it doesn't reinsert)
-                                    echo "<pre>DEBUG: Marking transaction as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:yellow;'>DEBUG CASE 2: Transaction ALREADY PROCESSED, ignoring</pre>";
                                 }
                                 
                                 $message = 'RejectedPayment';
                             }
                             break;
                         case 3: {
-                                echo "<pre style='background:orange;color:white;'>DEBUG CASE 3 - PENDING</pre>";
-                                var_dump("Entering case 3");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 // Check for duplicates
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
                                     //pending - restore stock
-                                    echo "<pre>DEBUG CASE 3: Processing pending</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -879,44 +820,27 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG CASE 3: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG CASE 3: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 3: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG CASE 3: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG CASE 3: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightsalmon;'>DEBUG CASE 3: Stock updated successfully</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG CASE 3: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -925,26 +849,17 @@ class EpaycoConfig
                                     }
                                     
                                     // Mark as processed
-                                    echo "<pre>DEBUG CASE 3: Marking as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:orange;'>DEBUG CASE 3: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 4: {
-                                echo "<pre style='background:red;color:white;'>DEBUG CASE 4 - FAILED</pre>";
-                                var_dump("Entering case 4");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 // Check for duplicates
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
                                     //failed - restore stock
-                                    echo "<pre>DEBUG CASE 4: Processing failed</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -956,44 +871,27 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG CASE 4: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG CASE 4: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 4: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG CASE 4: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG CASE 4: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightcoral;'>DEBUG CASE 4: Stock updated successfully</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG CASE 4: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1002,26 +900,17 @@ class EpaycoConfig
                                     }
                                     
                                     // Mark as processed
-                                    echo "<pre>DEBUG CASE 4: Marking as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:red;'>DEBUG CASE 4: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 6: {
-                                echo "<pre style='background:purple;color:white;'>DEBUG CASE 6</pre>";
-                                var_dump("Entering case 6");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 // Check for duplicates
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
                                     //pending - restore stock
-                                    echo "<pre>DEBUG CASE 6: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1033,44 +922,27 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG CASE 6: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG CASE 6: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 6: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG CASE 6: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG CASE 6: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightyellow;'>DEBUG CASE 6: Stock updated successfully</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG CASE 6: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1079,26 +951,17 @@ class EpaycoConfig
                                     }
                                     
                                     // Mark as processed
-                                    echo "<pre>DEBUG CASE 6: Marking as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:purple;'>DEBUG CASE 6: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 10: {
-                                echo "<pre style='background:navy;color:white;'>DEBUG CASE 10</pre>";
-                                var_dump("Entering case 10");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 // Check for duplicates
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
                                     //pending - restore stock
-                                    echo "<pre>DEBUG CASE 10: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1110,44 +973,27 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG CASE 10: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG CASE 10: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 10: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG CASE 10: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG CASE 10: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightblue;'>DEBUG CASE 10: Stock updated successfully</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG CASE 10: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1156,26 +1002,17 @@ class EpaycoConfig
                                     }
                                     
                                     // Mark as processed
-                                    echo "<pre>DEBUG CASE 10: Marking as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:navy;'>DEBUG CASE 10: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;
                         case 11: {
-                                echo "<pre style='background:teal;color:white;'>DEBUG CASE 11</pre>";
-                                var_dump("Entering case 11");
-                                var_dump("Invoice Status: " . $invoice['status']);
-                                
                                 // Check for duplicates
                                 $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
                                 $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                var_dump("Already processed: " . ($alreadyProcessed ? "YES" : "NO"));
                                 
                                 if ($result && !$alreadyProcessed) {
                                     //pending - restore stock
-                                    echo "<pre>DEBUG CASE 11: Processing</pre>";
                                     logTransaction($GATEWAY['name'], $validationData, "Failure");
 
                                     $productInfo = array();
@@ -1187,44 +1024,27 @@ class EpaycoConfig
                                         ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    echo "<pre>DEBUG CASE 11: Productos obtenidos</pre>";
-                                    var_dump($productsOrder);
-                                    
                                     foreach ($productsOrder as $productOrder) {
                                         $explodProduct = explode(' - ', $productOrder->description, 2);
                                         $productInfo[] = $explodProduct[0];
                                     }
                                     
-                                    echo "<pre>DEBUG CASE 11: Product Info Array</pre>";
-                                    var_dump($productInfo);
-                                    
                                     if (!empty($productInfo)) {
-                                        echo "<pre>DEBUG CASE 11: Entrando al IF de productInfo no vacío</pre>";
                                         $products = Capsule::table('tblproducts')
                                             ->whereIn('name', $productInfo)
                                             ->get(['name', 'qty'])
                                             ->all();
-
-                                        echo "<pre>DEBUG CASE 11: Productos de DB</pre>";
-                                        var_dump($products);
 
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty + 1;
                                         }
 
-                                        echo "<pre>DEBUG CASE 11: Product Data Array después de sumar qty</pre>";
-                                        var_dump($productData);
-
                                         for ($j = 0; $j < count($productData); $j++) {
                                             Capsule::table('tblproducts')
                                                 ->where('name', "=", $productData[$j]["name"])
                                                 ->update(['qty' => $productData[$j]["qty"]]);
                                         }
-                                        
-                                        echo "<pre style='background:lightseagreen;'>DEBUG CASE 11: Stock updated successfully</pre>";
-                                    } else {
-                                        echo "<pre>DEBUG CASE 11: ProductInfo is empty - NO PRODUCTS TO INCREASE STOCK</pre>";
                                     }
 
                                     if ($invoice['status'] != 'Cancelled') {
@@ -1233,10 +1053,7 @@ class EpaycoConfig
                                     }
                                     
                                     // Mark as processed
-                                    echo "<pre>DEBUG CASE 11: Marking as processed</pre>";
                                     Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                } else {
-                                    echo "<pre style='background:teal;'>DEBUG CASE 11: ALREADY PROCESSED, ignoring</pre>";
                                 }
                             }
                             break;

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -274,8 +274,8 @@ class EpaycoConfig
             $token = $tokenResponse['token'];
         }
         $dataScript  = array(
-            "name"=>substr($description, 0, 50),
-            "description"=>substr($description, 0, 50),
+            "name"=>substr($description, 0, 240),
+            "description"=>substr($description, 0, 240),
             "invoice"=>(string)$params['invoiceid'],
             "currency"=>strtolower($currencyCode),
             "amount"=>floatval($amount),
@@ -329,7 +329,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://epayco-checkout-testing.s3.amazonaws.com/checkout.preprod-v2.js">
+                src="https://checkout.epayco.co/checkout-v2.js">
             </script>
             <script>
                 var bntPagar = document.getElementById("btn_epayco");
@@ -420,7 +420,7 @@ class EpaycoConfig
     {        
        $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
         return $this->makeRequest($gateway,[], $url, "Bearer ".$bearer_token);
     }
     function makeRequest($gateway,$data,$url,$bearerToken = false){
@@ -473,7 +473,7 @@ class EpaycoConfig
                 'Authorization: Bearer '.$bearer_token
         );
 
-        $url = 'https://eks-apify-service.epayco.io/payment/session/create';
+        $url = 'https://apify.epayco.co/payment/session/create';
         $responseData = $this->PostCurl($url, $body, $headers);
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
@@ -502,7 +502,7 @@ class EpaycoConfig
         $data = array(
             'public_key' => $publicKey
         );
-        $url = 'https://eks-apify-service.epayco.io/login';
+        $url = 'https://apify.epayco.co/login';
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
@@ -800,7 +800,7 @@ class EpaycoConfig
         return $countries;
     }
     function ePaycoToken($gateway){
-       $url = "https://eks-apify-service.epayco.io/login";
+       $url = "https://apify.epayco.co/login";
        $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -829,7 +829,7 @@ class EpaycoConfig
         return $bearer_token;
     }
     function epaycoSessionPayment($gateway,$data,$bearer_token){
-        $url = "https://eks-apify-service.epayco.io/payment/session/create";
+        $url = "https://apify.epayco.co/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer ".$bearer_token);
     }
     function getCustomerIp(){

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -329,7 +329,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://epayco-checkout-testing.s3.amazonaws.com/checkout.preprod-v2.js">
+                src="https://checkout.epayco.co/checkout-v2.js">
             </script>
             <script>
                 var bntPagar = document.getElementById("btn_epayco");
@@ -420,7 +420,7 @@ class EpaycoConfig
     {        
        $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
         return $this->makeRequest($gateway,[], $url, "Bearer ".$bearer_token);
     }
     function makeRequest($gateway,$data,$url,$bearerToken = false){
@@ -473,7 +473,7 @@ class EpaycoConfig
                 'Authorization: Bearer '.$bearer_token
         );
 
-        $url = 'https://eks-apify-service.epayco.io/payment/session/create';
+        $url = 'https://apify.epayco.co/payment/session/create';
         $responseData = $this->PostCurl($url, $body, $headers);
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
@@ -502,7 +502,7 @@ class EpaycoConfig
         $data = array(
             'public_key' => $publicKey
         );
-        $url = 'https://eks-apify-service.epayco.io/login';
+        $url = 'https://apify.epayco.co/login';
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
@@ -800,7 +800,7 @@ class EpaycoConfig
         return $countries;
     }
     function ePaycoToken($gateway){
-       $url = "https://eks-apify-service.epayco.io/login";
+       $url = "https://apify.epayco.co/login";
        $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -829,7 +829,7 @@ class EpaycoConfig
         return $bearer_token;
     }
     function epaycoSessionPayment($gateway,$data,$bearer_token){
-        $url = "https://eks-apify-service.epayco.io/payment/session/create";
+        $url = "https://apify.epayco.co/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer ".$bearer_token);
     }
     function getCustomerIp(){

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -313,7 +313,7 @@ class EpaycoConfig
 
         $checkoutSessionResponse = $this->epaycoSessionCheckout($token, $dataScript);
         $sessionId = null;
-        
+
         if (is_array($checkoutSessionResponse) && isset($checkoutSessionResponse['success']) && $checkoutSessionResponse['success']) {
             if (isset($checkoutSessionResponse['data']) && is_array($checkoutSessionResponse['data'])) {
                 $sessionId = $checkoutSessionResponse["data"]['sessionId'];
@@ -321,7 +321,7 @@ class EpaycoConfig
         } else {
             $messageError = (is_array($checkoutSessionResponse) && isset($checkoutSessionResponse['textResponse'])) ? $checkoutSessionResponse['textResponse'] : '';
             $errorMessage = "";
-            
+
             if (isset($checkoutSessionResponse['data']['errors'])) {
                 $errors = $checkoutSessionResponse['data']['errors'];
                 if (is_array($errors)) {
@@ -339,7 +339,7 @@ class EpaycoConfig
                     }
                 }
             }
-            
+
             $processReturnFailMessage = !empty($errorMessage) ? $errorMessage : $messageError;
             echo sprintf(
                 '<div style="
@@ -358,7 +358,7 @@ class EpaycoConfig
             );
             return;
         }
-        
+
         $payload = array(
             'sessionId' => $sessionId,
             'type' => $externalMode,
@@ -604,7 +604,60 @@ class EpaycoConfig
     }
 
 
-       function callbackEpayco($idtrans, $confirmation)
+    function restoreProductStock($invoiceId, $quantityChange = 1)
+    {
+        // Obtener descripciones de productos del invoice
+        $productInfo = array();
+
+        $productsOrder = Capsule::table('tblinvoiceitems')
+            ->select('tblinvoiceitems.description')
+            ->where('tblinvoiceitems.invoiceid', '=', $invoiceId)
+            ->where('tblinvoiceitems.type', '=', 'Hosting')
+            ->get();
+
+        foreach ($productsOrder as $productOrder) {
+            $explodProduct = explode(' - ', $productOrder->description, 2);
+            $productInfo[] = $explodProduct[0];
+        }
+
+        // Actualizar cantidad en tblproducts
+        if (!empty($productInfo)) {
+            $products = Capsule::table('tblproducts')
+                ->whereIn('name', $productInfo)
+                ->get(['name', 'qty'])
+                ->all();
+
+            foreach ($products as $product) {
+                $newQty = $product->qty + $quantityChange;
+                Capsule::table('tblproducts')
+                    ->where('name', "=", $product->name)
+                    ->update(['qty' => $newQty]);
+            }
+        }
+    }
+
+
+    function handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, $logType = "Failure")
+    {
+        // Verificar si ya fue procesado
+        $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
+        $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
+
+        // Si no fue procesado, hacer todo
+        if ($result && !$alreadyProcessed) {
+            // Registrar log
+            logTransaction($GATEWAY['name'], $validationData, $logType);
+
+            // Restaurar stock (llamar la función que creamos)
+            $this->restoreProductStock($validationData['x_extra1'], 1);
+
+            // Marcar como procesado
+            Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+        }
+    }
+
+
+    function callbackEpayco($idtrans, $confirmation)
     {
 
         if ($confirmation) {
@@ -677,49 +730,18 @@ class EpaycoConfig
                                 if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
                                     // Check if there were previous retry attempts
                                     $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                    
+
                                     // hadPreviousFails = true if: transaction exists AND momento='0000-00-00 00:00:00' (was marked as processed after failure)
                                     // hadPreviousFails = false if: no transaction OR momento is not the special flag (direct payment)
                                     $hadPreviousFails = ($result && $result->momento === '0000-00-00 00:00:00');
-                                    
+
                                     if ($hadPreviousFails) {
                                         // There were previous failed attempts that we restored stock for
                                         // WHMCS already discounted on first attempt, we restored for each failure
                                         // Now we must discount again because payment succeeded
-                                        
-                                        $productInfo = array();
-                                        $productData = array();
-                                        
-                                        $productsOrder = Capsule::table('tblinvoiceitems')
-                                            ->select('tblinvoiceitems.description')
-                                            ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                            ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                            ->get();
-                                        
-                                        foreach ($productsOrder as $productOrder) {
-                                            $explodProduct = explode(' - ', $productOrder->description, 2);
-                                            $productInfo[] = $explodProduct[0];
-                                        }
-                                        
-                                        if (!empty($productInfo)) {
-                                            $products = Capsule::table('tblproducts')
-                                                ->whereIn('name', $productInfo)
-                                                ->get(['name', 'qty'])
-                                                ->all();
-
-                                            for ($i = 0; $i < count($products); $i++) {
-                                                $productData[$i]["name"] = $products[$i]->name;
-                                                $productData[$i]["qty"] =  $products[$i]->qty - 1;
-                                            }
-
-                                            for ($j = 0; $j < count($productData); $j++) {
-                                                Capsule::table('tblproducts')
-                                                    ->where('name', "=", $productData[$j]["name"])
-                                                    ->update(['qty' => $productData[$j]["qty"]]);
-                                            }
-                                        }
+                                        $this->restoreProductStock($validationData['x_extra1'], -1);
                                     }
-                                    
+
                                     addInvoicePayment(
                                         $invoice['invoiceid'],
                                         $validationData['x_ref_payco'],
@@ -742,306 +764,63 @@ class EpaycoConfig
                             }
                             break;
                         case 2: {
-                                //rejected - restore stock without duplicating
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                
-                                // Check if already processed (momento = 0000-00-00 is the flag)
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                
-                                if ($result && !$alreadyProcessed) {
-                                    logTransaction($GATEWAY['name'], $validationData, "Rejected");
+                              
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Rejected");
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
-
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-                                    
-                                    // Mark as processed (without deleting, so it doesn't reinsert)
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
-                                }
-                                
                                 $message = 'RejectedPayment';
                             }
                             break;
                         case 3: {
-                                // Check for duplicates
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                
-                                if ($result && !$alreadyProcessed) {
-                                    //pending - restore stock
-                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+                              
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Failure");
 
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-
-                                    if ($invoice['status'] != 'Cancelled') {
-                                        $message = 'PendingOrder';
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                    }
-                                    
-                                    // Mark as processed
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $message = 'PendingOrder';
+                                    $results = localAPI($message, $postData, $adminUsername);
                                 }
                             }
                             break;
                         case 4: {
-                                // Check for duplicates
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
                                 
-                                if ($result && !$alreadyProcessed) {
-                                    //failed - restore stock
-                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Failure");
 
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-
-                                    if ($invoice['status'] != 'Cancelled') {
-                                        $message = 'PendingOrder';
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                    }
-                                    
-                                    // Mark as processed
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $message = 'PendingOrder';
+                                    $results = localAPI($message, $postData, $adminUsername);
                                 }
                             }
                             break;
                         case 6: {
-                                // Check for duplicates
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                
-                                if ($result && !$alreadyProcessed) {
-                                    //pending - restore stock
-                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+                               
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Failure");
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
-
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-
-                                    if ($invoice['status'] != 'Cancelled') {
-                                        $message = 'PendingOrder';
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                    }
-                                    
-                                    // Mark as processed
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $message = 'PendingOrder';
+                                    $results = localAPI($message, $postData, $adminUsername);
                                 }
                             }
                             break;
                         case 10: {
-                                // Check for duplicates
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                
-                                if ($result && !$alreadyProcessed) {
-                                    //pending - restore stock
-                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+                              
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Failure");
 
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-
-                                    if ($invoice['status'] != 'Cancelled') {
-                                        $message = 'PendingOrder';
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                    }
-                                    
-                                    // Mark as processed
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $message = 'PendingOrder';
+                                    $results = localAPI($message, $postData, $adminUsername);
                                 }
                             }
                             break;
                         case 11: {
-                                // Check for duplicates
-                                $result = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->first();
-                                $alreadyProcessed = ($result && $result->momento === '0000-00-00 00:00:00');
-                                
-                                if ($result && !$alreadyProcessed) {
-                                    //pending - restore stock
-                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+                               
 
-                                    $productInfo = array();
-                                    $productData = array();
-                                    
-                                    $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->select('tblinvoiceitems.description')
-                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                        ->get();
-                                    
-                                    foreach ($productsOrder as $productOrder) {
-                                        $explodProduct = explode(' - ', $productOrder->description, 2);
-                                        $productInfo[] = $explodProduct[0];
-                                    }
-                                    
-                                    if (!empty($productInfo)) {
-                                        $products = Capsule::table('tblproducts')
-                                            ->whereIn('name', $productInfo)
-                                            ->get(['name', 'qty'])
-                                            ->all();
+                                $this->handleFailedTransaction($mp_transaction, $GATEWAY, $validationData, "Failure");
 
-                                        for ($i = 0; $i < count($products); $i++) {
-                                            $productData[$i]["name"] = $products[$i]->name;
-                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                        }
-
-                                        for ($j = 0; $j < count($productData); $j++) {
-                                            Capsule::table('tblproducts')
-                                                ->where('name', "=", $productData[$j]["name"])
-                                                ->update(['qty' => $productData[$j]["qty"]]);
-                                        }
-                                    }
-
-                                    if ($invoice['status'] != 'Cancelled') {
-                                        $message = 'PendingOrder';
-                                        $results = localAPI($message, $postData, $adminUsername);
-                                    }
-                                    
-                                    // Mark as processed
-                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaction)->update(['momento' => '0000-00-00 00:00:00']);
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $message = 'PendingOrder';
+                                    $results = localAPI($message, $postData, $adminUsername);
                                 }
                             }
                             break;
@@ -1151,26 +930,26 @@ class EpaycoConfig
         if (function_exists('iconv')) {
             $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string);
         }
-        
+
         $strip = array("~", "`", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "=", "+", "[", "{", "]", "}", "\\", "|", ";", ":", "\"", "'", "&#8216;", "&#8217;", "&#8220;", "&#8221;", "&#8211;", "&#8212;", "â€”", "â€“", ",", "<", ".", ">", "/", "?", "-");
         $clean = trim(str_replace($strip, "", strip_tags($string)));
         $clean = preg_replace('/\s+/', ' ', $clean);
         $clean = ($anal) ? preg_replace("/[^a-zA-Z0-9]/", "", $clean) : $clean;
         return $clean;
     }
-    
+
     function normalizeDecimalValue($value)
     {
         // Remove spaces and trim
         $value = trim($value);
-        
+
         // Remove currency symbols and letters
         $value = preg_replace('/[^0-9.,]/', '', $value);
-        
+
         // Count occurrences of dots and commas
         $dotCount = substr_count($value, '.');
         $commaCount = substr_count($value, ',');
-        
+
         // Determine the decimal separator based on format
         if ($dotCount == 0 && $commaCount == 1) {
             // Format: "1234,56" - comma is decimal separator (European without thousands)
@@ -1189,11 +968,11 @@ class EpaycoConfig
             // Format: "1,234,567" - commas are thousand separators (US), no decimal
             $value = str_replace(',', '', $value);
         }
-        
+
         // Convert to float
         return floatval($value);
     }
-    
+
     function epayco_getAdminUserWithApiAccess()
     {
         try {

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -468,7 +468,7 @@ class EpaycoConfig
     {
         $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaction . "&&public_key=" . $publicKey;
+        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=" . $transaction . "&&public_key=" . $publicKey;
         return $this->makeRequest($gateway, [], $url, "Bearer " . $bearer_token);
     }
     function makeRequest($gateway, $data, $url, $bearerToken = false)

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -230,12 +230,10 @@ class EpaycoConfig
         $address1 = $params['clientdetails']['address1'];
         $returnUrl = $params['returnurl'];
         $billing_name = $firstname . " " . $lastname;
-        if ($params['currencyCode'] == 'default') {
-            $clientDetails = localAPI("getclientsdetails", ["clientid" => $params['clientdetails']['userid'], "responsetype" => "json"], $params['WHMCSAdminUser']);
-            $currencyCode = strtolower($clientDetails['currency_code']);
-        } else {
-            $currencyCode = $params['currencyCode'];
-        }
+        
+        // Get store currency from client
+        $clientDetails = localAPI("getclientsdetails", ["clientid" => $params['clientdetails']['userid'], "responsetype" => "json"], $params['WHMCSAdminUser']);
+        $currencyCode = strtolower($clientDetails['currency_code']);
 
         $testMode = $params['testMode'] == 'on' ? true : false;
 
@@ -376,7 +374,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://checkout.epayco.co/checkout-v2.js">
+                src="https://epayco-checkout-testing.s3.amazonaws.com/checkout.preprod-v2.js">
             </script>
             <script>
                 var bntPagar = document.getElementById("btn_epayco");
@@ -468,7 +466,7 @@ class EpaycoConfig
     {
         $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
+        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
         return $this->makeRequest($gateway, [], $url, "Bearer " . $bearer_token);
     }
     function makeRequest($gateway, $data, $url, $bearerToken = false)
@@ -523,7 +521,7 @@ class EpaycoConfig
             'Authorization: Bearer ' . $bearer_token
         );
 
-        $url = 'https://apify.epayco.co/payment/session/create';
+        $url = 'https://eks-apify-service.epayco.io/payment/session/create';
         $responseData = $this->PostCurl($url, $body, $headers);
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
@@ -552,7 +550,7 @@ class EpaycoConfig
         $data = array(
             'public_key' => $publicKey
         );
-        $url = 'https://apify.epayco.co/login';
+        $url = 'https://eks-apify-service.epayco.io/login';
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
@@ -975,7 +973,7 @@ class EpaycoConfig
     }
     function ePaycoToken($gateway)
     {
-        $url = "https://apify.epayco.co/login";
+        $url = "https://eks-apify-service.epayco.io/login";
         $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -1005,7 +1003,7 @@ class EpaycoConfig
     }
     function epaycoSessionPayment($gateway, $data, $bearer_token)
     {
-        $url = "https://apify.epayco.co/payment/session/create";
+        $url = "https://eks-apify-service.epayco.io/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer " . $bearer_token);
     }
     function getCustomerIp()

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -1,12 +1,16 @@
 <?php
+
 use Illuminate\Database\Capsule\Manager as Capsule;
+
 require_once(__DIR__ . "/idioma.php");
+
 use WHMCS\Exception;
+
 class EpaycoConfig
-{ 
+{
     public $nombreModulo;
     public $modulo;
-    public function __construct($nombreModulo = "epayco",$modulo = "epayco")
+    public function __construct($nombreModulo = "epayco", $modulo = "epayco")
     {
         $this->nombreModulo = $nombreModulo;
         $this->modulo = $modulo;
@@ -24,7 +28,7 @@ class EpaycoConfig
                     $table->string("refPayco");
                 });
                 return true;
-            } catch(\Exception $ex) {
+            } catch (\Exception $ex) {
                 throw new Exception("No se pudo crear la tabla de transacciones: " . $ex->getMessage());
             }
         }
@@ -37,7 +41,7 @@ class EpaycoConfig
             try {
                 WHMCS\Database\Capsule::schema()->dropIfExists($nombreTabla);
                 return true;
-            } catch(\Exception $ex) {
+            } catch (\Exception $ex) {
                 throw new Exception("No se pudo eliminar la tabla de transacciones: " . $ex->getMessage());
             }
         }
@@ -51,8 +55,8 @@ class EpaycoConfig
             $resultado = "es";
         }
         return $resultado;
-    }    
-    
+    }
+
     function getPreferenciaPago($accesstoken, $datos_mp, $prueba = false)
     {
         $userid = substr(strrchr($accesstoken, "-"), 1);
@@ -78,89 +82,89 @@ class EpaycoConfig
         $idioma = $this->checkIdioma();
         $usersWithApiAccess = $this->epayco_getAdminUserWithApiAccess();
         $usersWithApiAccessArray = array();
-        foreach($usersWithApiAccess as $userWithApiAccess){
+        foreach ($usersWithApiAccess as $userWithApiAccess) {
             $usersWithApiAccessArray[$userWithApiAccess->username] = $userWithApiAccess->username;
         }
         $configHeader = array(
-                "FriendlyName" => array(
-                    "Type" => "System", 
-                    "Value" => $nombre
-                ), 
-                'customerID' => array(
-                    'FriendlyName' => 'P_CUST_ID_CLIENTE',
-                    'Type' => 'text',
-                    'Size' => '32',
-                    'Default' => '',
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_1"),
-                ),
-                'publicKey' => array(
-                    'FriendlyName' => 'PUBLIC_KEY',
-                    'Type' => 'text',
-                    'Size' => '32',
-                    'Default' => '',
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_2"),
-                ),
-                'privateKey' => array(
-                    'FriendlyName' => 'PRIVATE_KEY',
-                    'Type' => 'text',
-                    'Size' => '32',
-                    'Default' => '',
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_2"),
-                ),
-                'p_key' => array(
-                    'FriendlyName' => 'P_KEY',
-                    'Type' => 'text',
-                    'Size' => '32',
-                    'Default' => '',
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_3"),
-                ),
-                /*'countryCode' => array(
+            "FriendlyName" => array(
+                "Type" => "System",
+                "Value" => $nombre
+            ),
+            'customerID' => array(
+                'FriendlyName' => 'P_CUST_ID_CLIENTE',
+                'Type' => 'text',
+                'Size' => '32',
+                'Default' => '',
+                'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_1"),
+            ),
+            'publicKey' => array(
+                'FriendlyName' => 'PUBLIC_KEY',
+                'Type' => 'text',
+                'Size' => '32',
+                'Default' => '',
+                'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_2"),
+            ),
+            'privateKey' => array(
+                'FriendlyName' => 'PRIVATE_KEY',
+                'Type' => 'text',
+                'Size' => '32',
+                'Default' => '',
+                'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_2"),
+            ),
+            'p_key' => array(
+                'FriendlyName' => 'P_KEY',
+                'Type' => 'text',
+                'Size' => '32',
+                'Default' => '',
+                'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_3"),
+            ),
+            /*'countryCode' => array(
                     'FriendlyName' => traduccionEpayco($idioma, "epconfig_4"),
                     'Type' => 'dropdown',
                     'Options' => $this->epayco_loadCountries(),
                     'Description' => traduccionEpayco($idioma, "epconfig_5"),
                 ),*/
-                'currencyCode' => array(
-                    'FriendlyName' => traduccionEpayco($idioma, "epconfig_6"),
-                    'Type' => 'dropdown',
-                    'Options' => array(
-                        'default' => traduccionEpayco($idioma, "epconfig_7"),
-                        'cop' => traduccionEpayco($idioma, "epconfig_8"),
-                        'usd' => traduccionEpayco($idioma, "epconfig_9")
-                    ),
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_10"),
+            // 'currencyCode' => array(
+            //     'FriendlyName' => traduccionEpayco($idioma, "epconfig_6"),
+            //     'Type' => 'dropdown',
+            //     'Options' => array(
+            //         'default' => traduccionEpayco($idioma, "epconfig_7"),
+            //         'cop' => traduccionEpayco($idioma, "epconfig_8"),
+            //         'usd' => traduccionEpayco($idioma, "epconfig_9")
+            //     ),
+            //     'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_10"),
+            // ),
+            'lang' => array(
+                'FriendlyName' => traduccionEpayco($idioma, "epconfig_11"),
+                'Type' => 'dropdown',
+                'Options' => array(
+                    'es' => traduccionEpayco($idioma, "epconfig_12"),
+                    'en' => traduccionEpayco($idioma, "epconfig_13")
                 ),
-                'lang' => array(
-                    'FriendlyName' => traduccionEpayco($idioma, "epconfig_11"),
-                    'Type' => 'dropdown',
-                    'Options' => array(
-                        'es' => traduccionEpayco($idioma, "epconfig_12"),
-                        'en' => traduccionEpayco($idioma, "epconfig_13")
-                    ),
-                    'Description' => '<br/>'.traduccionEpayco($idioma, "epconfig_14"),
-                ),
-                'testMode' => array(
-                    'FriendlyName' => traduccionEpayco($idioma, "epconfig_15"),
-                    'Type' => 'yesno',
-                    'Description' => traduccionEpayco($idioma, "epconfig_16"),
-                ),
-                'externalMode' => array(
-                    'FriendlyName' => 'Standar checkout',
-                    'Type' => 'yesno',
-                    'Description' => traduccionEpayco($idioma, "epconfig_17"),
-                ),
-                /*"bh_texto" => array(
+                'Description' => '<br/>' . traduccionEpayco($idioma, "epconfig_14"),
+            ),
+            'testMode' => array(
+                'FriendlyName' => traduccionEpayco($idioma, "epconfig_15"),
+                'Type' => 'yesno',
+                'Description' => traduccionEpayco($idioma, "epconfig_16"),
+            ),
+            'externalMode' => array(
+                'FriendlyName' => 'Standar checkout',
+                'Type' => 'yesno',
+                'Description' => traduccionEpayco($idioma, "epconfig_17"),
+            ),
+            /*"bh_texto" => array(
                     "FriendlyName" => "" . traduccionEpayco($idioma, "epconfig_22") . "", 
                     "Type" => "text", 
                     "Value" => traduccionEpayco($idioma, "epconfig_23")
                 ),*/
-                "bh_nota" => array(
-                    "FriendlyName" => traduccionEpayco($idioma, "epconfig_20") . ":", 
-                    "Type" => "text", 
-                    "Size" => "100", 
-                    "Description" => "<br>" . traduccionEpayco($idioma, "epconfig_21")
-                ),
-                /*"color" => array(
+            "bh_nota" => array(
+                "FriendlyName" => traduccionEpayco($idioma, "epconfig_20") . ":",
+                "Type" => "text",
+                "Size" => "100",
+                "Description" => "<br>" . traduccionEpayco($idioma, "epconfig_21")
+            ),
+            /*"color" => array(
                     "FriendlyName" => traduccionEpayco($idioma, "epconfig_24") . ":", 
                     "Type" => "dropdown", 
                     "Options" => array(
@@ -181,11 +185,10 @@ class EpaycoConfig
                     "Description" => traduccionEpayco($idioma, "epconfig_36")
                 )
                 */
-            );
+        );
         return $configHeader;
-
     }
-    
+
     function getLinkPago($params)
     {
         $companyname = $params["companyname"];
@@ -203,7 +206,7 @@ class EpaycoConfig
         } else {
             $mododeprueba = false;
         }
-      
+
 
         $bh_success = $params["bh_success"];
         $bh_pending = $params["bh_pending"];
@@ -226,75 +229,75 @@ class EpaycoConfig
         $email = $params['clientdetails']['email'];
         $address1 = $params['clientdetails']['address1'];
         $returnUrl = $params['returnurl'];
-        $billing_name = $firstname." ".$lastname;
-        if($params['currencyCode'] == 'default'){
+        $billing_name = $firstname . " " . $lastname;
+        if ($params['currencyCode'] == 'default') {
             $clientDetails = localAPI("getclientsdetails", ["clientid" => $params['clientdetails']['userid'], "responsetype" => "json"], $params['WHMCSAdminUser']);
             $currencyCode = strtolower($clientDetails['currency_code']);
-        }else {
+        } else {
             $currencyCode = $params['currencyCode'];
         }
 
         $testMode = $params['testMode'] == 'on' ? true : false;
-    
+
         $externalMode = $params['externalMode'] == 'on' ? 'standard' : 'onepage';
-    
+
         $invoice = localAPI("getinvoice", array('invoiceid' => $params['invoiceid']), $params['WHMCSAdminUser']);
         $invoiceData = Capsule::table('tblorders')
             ->select('tblorders.id')
             ->where('tblorders.invoiceid', '=', $params['invoiceid'])
             ->get();
-    
+
         $description = $this->epayco_getChargeDescription($invoice['items']['item']);
-        if(floatval($invoice["subtotal"]) > 0.0 ){
-            $tax=floatval($invoice["tax"]);
-            $sub_total = floatval($invoice["subtotal"]);
-            $amount = floatval($invoice["total"]);
-        }else{
-            $tax="0";
-            $sub_total = $params["amount"];
-            $amount = $params["amount"];
+        if (floatval($invoice["subtotal"]) > 0.0) {
+            $tax = $this->normalizeDecimalValue($invoice["tax"]);
+            $sub_total = $this->normalizeDecimalValue($invoice["subtotal"]);
+            $amount = $this->normalizeDecimalValue($invoice["total"]);
+        } else {
+            $tax = 0.0;
+            $sub_total = $this->normalizeDecimalValue($params["amount"]);
+            $amount = $this->normalizeDecimalValue($params["amount"]);
         }
         $sub_total = $amount - $tax;
         $confirmationUrl = $systemurl . "modules/gateways/callback/" . $params["paymentmethod"] . ".php?source_news=webhooks";
         $lang = $params['lang'];
         if ($lang === "en") {
             $epaycoButtonImage = 'https://multimedia.epayco.co/epayco-landing/btns/Boton-epayco-color-Ingles.png';
-        }else{
+        } else {
             $epaycoButtonImage = 'https://multimedia.epayco.co/epayco-landing/btns/Boton-epayco-color1.png';
         }
-        $ip=$this->getCustomerIp(); 
-        $logo = $params['systemurl'].'/modules/gateways/epayco/logo.png';
+        $ip = $this->getCustomerIp();
+        $logo = $params['systemurl'] . '/modules/gateways/epayco/logo.png';
         $code = "<img src=" . $logo . " /><br><a href='" . $enlace . "' class='btn btn-" . $color . "'>" . $bh_texto . "</a>" . $nota;
         $tokenResponse = $this->epaycoBerarToken(
             $params['publicKey'],
             $params['privateKey']
         );
-         $token = null;
-        if(isset($tokenResponse['token'])){
+        $token = null;
+        if (isset($tokenResponse['token'])) {
             $token = $tokenResponse['token'];
         }
         $dataScript  = array(
-            "name"=>substr($description, 0, 240),
-            "description"=>substr($description, 0, 240),
-            "invoice"=>(string)$params['invoiceid'],
-            "currency"=>strtolower($currencyCode),
-            "amount"=>floatval($amount),
-            "taxBase"=>floatval($sub_total),
-            "tax"=>floatval($tax),
-            "taxIco"=>floatval(0),
-            "country"=>$countryCode,
-            "lang"=>$lang,
-            "confirmation"=>$confirmationUrl,
-            "response"=> $confirmationUrl,
+            "name" => substr($this->string_sanitize($description), 0, 240),
+            "description" => substr($this->string_sanitize($description), 0, 240),
+            "invoice" => (string)$params['invoiceid'],
+            "currency" => strtolower($currencyCode),
+            "amount" => $amount,
+            "taxBase" => $sub_total,
+            "tax" => $tax,
+            "taxIco" => 0.0,
+            "country" => $countryCode,
+            "lang" => $lang,
+            "confirmation" => $confirmationUrl,
+            "response" => $confirmationUrl,
             "billing" => [
-                "name" =>$billing_name,
+                "name" => $billing_name,
                 "address" => $address1,
                 "email" => $email,
             ],
-            "autoclick"=> true,
-            "ip"=>$ip,
-            "test"=>$testMode,
-             "extras" => [
+            "autoclick" => true,
+            "ip" => $ip,
+            "test" => $testMode,
+            "extras" => [
                 "extra1" => (string)$params['invoiceid'],
                 "extra2" => (string)$invoiceData[0]->id,
                 "extra3" => $lang
@@ -303,28 +306,72 @@ class EpaycoConfig
                 "extra5" => "P34"
             ],
             "epaycoMethodsDisable" => [],
-            "method"=> "POST",
-            "checkout_version"=>"2",
+            "method" => "POST",
+            "checkout_version" => "2",
             "autoClick" => false,
         );
 
         $checkoutSessionResponse = $this->epaycoSessionCheckout($token, $dataScript);
         $sessionId = null;
-        if(isset($checkoutSessionResponse['success'])){
-            $sessionId = $checkoutSessionResponse["data"]['sessionId'];
+        
+        if (is_array($checkoutSessionResponse) && isset($checkoutSessionResponse['success']) && $checkoutSessionResponse['success']) {
+            if (isset($checkoutSessionResponse['data']) && is_array($checkoutSessionResponse['data'])) {
+                $sessionId = $checkoutSessionResponse["data"]['sessionId'];
+            }
+        } else {
+            $messageError = (is_array($checkoutSessionResponse) && isset($checkoutSessionResponse['textResponse'])) ? $checkoutSessionResponse['textResponse'] : '';
+            $errorMessage = "";
+            
+            if (isset($checkoutSessionResponse['data']['errors'])) {
+                $errors = $checkoutSessionResponse['data']['errors'];
+                if (is_array($errors)) {
+                    foreach ($errors as $error) {
+                        $errorMessage .= $error['errorMessage'] . "\n";
+                    }
+                } else {
+                    $errorMessage = $errors . "\n";
+                }
+            } elseif (isset($checkoutSessionResponse['data']['error']['errores'])) {
+                $errores = $checkoutSessionResponse['data']['error']['errores'];
+                if (is_array($errores)) {
+                    foreach ($errores as $error) {
+                        $errorMessage .= $error['errorMessage'] . "\n";
+                    }
+                }
+            }
+            
+            $processReturnFailMessage = !empty($errorMessage) ? $errorMessage : $messageError;
+            echo sprintf(
+                '<div style="
+                    display: flex;
+                    align-items: center;
+                    flex-direction: column;
+                ">
+                    <div>
+                        <img style="width: 80px;" src="https://multimedia-epayco-preprod.s3.us-east-1.amazonaws.com/plugins-sdks/warning.png" alt="" />
+                    </div>
+                    <div style="text-align: center;font-size: large;font-weight: 900;">
+                        <p>"%s"</p>
+                    </div>
+                </div>',
+                $processReturnFailMessage
+            );
+            return;
         }
+        
         $payload = array(
             'sessionId' => $sessionId,
             'type' => $externalMode,
             'test' => $testMode,
         );
 
-        $checkout =  base64_encode(json_encode($payload));  
-        $code = sprintf('
+        $checkout =  base64_encode(json_encode($payload));
+        $code = sprintf(
+            '
             <p>       
                 <center>
                 <a id="btn_epayco" href="#">
-                    <img src="'.$epaycoButtonImage.'">
+                    <img src="' . $epaycoButtonImage . '">
                 </a>
                 </center> 
             </p>
@@ -369,22 +416,23 @@ class EpaycoConfig
                 });
             </script>
         %s
-        ',  
-         $checkout,
-         $nota
+        ',
+            $checkout,
+            $nota
         );
         return $code;
     }
-    function epayco_getChargeDescription($invoceItems){
+    function epayco_getChargeDescription($invoceItems)
+    {
         $descriptions = array();
-        foreach($invoceItems as $item){
+        foreach ($invoceItems as $item) {
             $clearData = str_replace('_', ' ', $this->string_sanitize($item['description']));
             $descriptions[] = $clearData;
         }
         return implode(' - ', $descriptions);
     }
 
-    function epaycoConfirmation($gatewayOBJ,$informe,$confirmation=false)
+    function epaycoConfirmation($gatewayOBJ, $informe, $confirmation = false)
     {
         $gatewayModule = $this->modulo;
         //$informes = json_decode(file_get_contents("php://input"), true);
@@ -414,63 +462,65 @@ class EpaycoConfig
             Capsule::table("bapp_epayco")->insert(array("transaccion" => $informe_cobro, "momento" => date("Y-m-d H:i:s"), "gateway" => $gatewayModule, "refPayco" => $informe['x_ref_payco']));
         }
 
-        return $this->callbackEpayco($informe,$confirmation);
+        return $this->callbackEpayco($informe, $confirmation);
     }
     function getPaymentEpayco($gateway, $transaccion)
-    {        
-       $bearer_token = $this->ePaycoToken($gateway);
+    {
+        $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://secure.payco.co/transaction/response.json?ref_payco=".$transaccion."&&public_key=".$publicKey;
-        return $this->makeRequest($gateway,[], $url, "Bearer ".$bearer_token);
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
+        return $this->makeRequest($gateway, [], $url, "Bearer " . $bearer_token);
     }
-    function makeRequest($gateway,$data,$url,$bearerToken = false){
+    function makeRequest($gateway, $data, $url, $bearerToken = false)
+    {
         $headers["Content-Type"] = 'application/json';
-        if(!$bearerToken){
-            $bearerToken = 'Bearer '.$token;
-        }else{
-            $token = base64_encode($gateway['publicKey'].":".$gateway['privateKey']);
-            $bearerToken = 'Basic '.$token;
+        if (!$bearerToken) {
+            $bearerToken = 'Bearer ' . $token;
+        } else {
+            $token = base64_encode($gateway['publicKey'] . ":" . $gateway['privateKey']);
+            $bearerToken = 'Basic ' . $token;
         }
-            try {
-                $headers = array(
-                    'Content-Type: application/json',
-                    'Authorization: '.$bearerToken
-                  );
-                if(!empty($data)){
-                    $jsonData = json_encode($data);
-                }else{
-                    $jsonData = null;
-                }
-                
-
-                $curl = curl_init();
-                curl_setopt_array($curl, array(
-                  CURLOPT_URL => $url,
-                  CURLOPT_RETURNTRANSFER => true,
-                  CURLOPT_ENCODING => '',
-                  CURLOPT_MAXREDIRS => 10,
-                  CURLOPT_TIMEOUT => 0,
-                  CURLOPT_FOLLOWLOCATION => true,
-                  CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
-                  CURLOPT_CUSTOMREQUEST => 'POST',
-                  CURLOPT_POSTFIELDS => $jsonData,
-                  CURLOPT_HTTPHEADER => $headers,
-                ));
-                $resp = curl_exec($curl);
-                if ($resp === false) {
-                    return;
-                }
-                curl_close($curl);
-                return json_decode($resp);
-            } catch(\Exception $ex) {
-                throw new Exception("No se pudo consultar la transaccion: " . $ex->getMessage());
-            }
-    }
-    
-    function epaycoSessionCheckout($bearer_token, $body){
-        $headers = array(
+        try {
+            $headers = array(
                 'Content-Type: application/json',
-                'Authorization: Bearer '.$bearer_token
+                'Authorization: ' . $bearerToken
+            );
+            if (!empty($data)) {
+                $jsonData = json_encode($data);
+            } else {
+                $jsonData = null;
+            }
+
+
+            $curl = curl_init();
+            curl_setopt_array($curl, array(
+                CURLOPT_URL => $url,
+                CURLOPT_RETURNTRANSFER => true,
+                CURLOPT_ENCODING => '',
+                CURLOPT_MAXREDIRS => 10,
+                CURLOPT_TIMEOUT => 0,
+                CURLOPT_FOLLOWLOCATION => true,
+                CURLOPT_HTTP_VERSION => CURL_HTTP_VERSION_1_1,
+                CURLOPT_CUSTOMREQUEST => 'POST',
+                CURLOPT_POSTFIELDS => $jsonData,
+                CURLOPT_HTTPHEADER => $headers,
+            ));
+            $resp = curl_exec($curl);
+            if ($resp === false) {
+                return;
+            }
+            curl_close($curl);
+            return json_decode($resp);
+        } catch (\Exception $ex) {
+            throw new Exception("No se pudo consultar la transaccion: " . $ex->getMessage());
+        }
+    }
+
+    function epaycoSessionCheckout($bearer_token, $body)
+    {
+        $headers = array(
+            'Content-Type: application/json',
+            'Authorization: Bearer ' . $bearer_token
         );
 
         $url = 'https://apify.epayco.co/payment/session/create';
@@ -478,13 +528,13 @@ class EpaycoConfig
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
     }
-    
-    function epaycoBerarToken($public_key,$private_key)
+
+    function epaycoBerarToken($public_key, $private_key)
     {
         $publicKey = trim($public_key);
         $privateKey = trim($private_key);
         $bearer_token = base64_encode($publicKey . ":" . $privateKey);
-        
+
         if (!isset($_COOKIE[$publicKey])) {
             $token = base64_encode($publicKey . ":" . $privateKey);
             $bearer_token = $token;
@@ -493,10 +543,10 @@ class EpaycoConfig
         } else {
             $bearer_token = $_COOKIE[$publicKey];
         }
-        
+
         $headers = array(
-                'Content-Type: application/json',
-                'Authorization: Basic '.$bearer_token
+            'Content-Type: application/json',
+            'Authorization: Basic ' . $bearer_token
         );
 
         $data = array(
@@ -506,12 +556,12 @@ class EpaycoConfig
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
-        return $jsonData ;
+        return $jsonData;
     }
-    
-    function PostCurl($url, $body, $headers, $method='POST')
+
+    function PostCurl($url, $body, $headers, $method = 'POST')
     {
-        try{
+        try {
             // Inicializamos cURL
             $ch = curl_init();
             $timeout = 5;
@@ -519,7 +569,7 @@ class EpaycoConfig
 
             // Configuraciones de cURL
             curl_setopt($ch, CURLOPT_URL, $url);
-            if(!$body){
+            if (!$body) {
                 curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);    // Desactivar verificación de certificado SSL
                 curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, false);    // Desactivar verificación de host SSL
                 curl_setopt($ch, CURLOPT_USERAGENT, $user_agent);   // Establecer el agente de usuario
@@ -527,19 +577,19 @@ class EpaycoConfig
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);        // Devolver la respuesta como string
                 curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout); // Tiempo de conexión máximo
                 curl_setopt($ch, CURLOPT_MAXREDIRS, 10);            // Máximo de redirecciones permitidas
-            }else{
+            } else {
                 $jsonData = json_encode($body);
                 curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
-                curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method); 
-                curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonData); 
+                curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $method);
+                curl_setopt($ch, CURLOPT_POSTFIELDS, $jsonData);
                 curl_setopt($ch, CURLOPT_FOLLOWLOCATION, 1); // Seguir redirecciones
                 curl_setopt($ch, CURLOPT_TIMEOUT, $timeout); // Tiempo de espera máximo
                 curl_setopt($ch, CURLOPT_RETURNTRANSFER, true); // Tiempo de espera máximo
-                curl_setopt($ch,CURLOPT_SSLKEYPASSWD, '');
-                curl_setopt($ch,CURLOPT_ENCODING, "");
-                curl_setopt($ch,CURLOPT_MAXREDIRS, 10);
-                curl_setopt($ch,CURLOPT_TIMEOUT, 600);
-                curl_setopt($ch,CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+                curl_setopt($ch, CURLOPT_SSLKEYPASSWD, '');
+                curl_setopt($ch, CURLOPT_ENCODING, "");
+                curl_setopt($ch, CURLOPT_MAXREDIRS, 10);
+                curl_setopt($ch, CURLOPT_TIMEOUT, 600);
+                curl_setopt($ch, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
             }
             $data = curl_exec($ch);
             if ($data === false) {
@@ -548,15 +598,15 @@ class EpaycoConfig
             curl_close($ch);
 
             return $data;
-        } catch(\Exception $ex) {
+        } catch (\Exception $ex) {
             throw new Exception("No se pudorealizar la accion: " . $ex->getMessage());
         }
     }
-    
-    function callbackEpayco($idtrans,$confirmation)
+
+    function callbackEpayco($idtrans, $confirmation)
     {
 
-        if($confirmation){
+        if ($confirmation) {
             if (!empty($idtrans['x_extra1'])) {
                 $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $idtrans['x_extra1'])->get();
                 $mp_id = $resultado[0]->id;
@@ -572,14 +622,13 @@ class EpaycoConfig
                 $mp_gateway = $resultado->gateway;
                 $ref_payco = $resultado->refPayco;
             }
-            
-        }else{
+        } else {
             $mp_transaccion = $idtrans['x_extra1'];
             $mp_gateway = 'epayco';
             $ref_payco = $idtrans['x_ref_payco'];
         }
         $GATEWAY = getGatewayVariables($mp_gateway);
- 
+
         if (!empty($mp_transaccion)) {
 
             $admin = $GATEWAY["useradmin"];
@@ -590,176 +639,301 @@ class EpaycoConfig
             $command = "GetInvoice";
             $postData = array("invoiceid" => $mp_transaccion);
             $invoice = localAPI($command, $postData, $adminUsername);
-   
+
             if ($invoice["result"] == 'success') {
-           
-                if($confirmation){
-                     //$validationData = $this->getPaymentEpayco($GATEWAY,$ref_payco);
-                     $validationData = $idtrans;
-                }else{
+
+                if ($confirmation) {
+                    //$validationData = $this->getPaymentEpayco($GATEWAY,$ref_payco);
+                    $validationData = $idtrans;
+                } else {
                     $validationData = $idtrans;
                 }
-                $signature = hash('sha256',
-                 trim($GATEWAY['customerID']).'^'
-                 .trim($GATEWAY['p_key']).'^'
-                 .$idtrans['x_ref_payco'].'^'
-                 .$idtrans['x_transaction_id'].'^'
-                 .$idtrans['x_amount'].'^'
-                 .$idtrans['x_currency_code']
+                $signature = hash(
+                    'sha256',
+                    trim($GATEWAY['customerID']) . '^'
+                        . trim($GATEWAY['p_key']) . '^'
+                        . $idtrans['x_ref_payco'] . '^'
+                        . $idtrans['x_transaction_id'] . '^'
+                        . $idtrans['x_amount'] . '^'
+                        . $idtrans['x_currency_code']
                 );
                 $invoiceData = Capsule::table('tblorders')
                     ->select('tblorders.amount')
                     ->where('tblorders.invoiceid', '=', $validationData['x_extra1'])
                     ->get();
                 $invoiceAmount = $invoiceData[0]->amount;
-                $x_amount= $validationData['x_amount'];
+                $x_amount = $validationData['x_amount'];
                 /*if(floatval($invoiceAmount) === floatval($x_amount)){
                         $validation = true;
                 }else{
                     $validation = false;
                 }*/
                 $validation = true;
-                if(($signature == $validationData['x_signature'] || $validationData['x_signature'] == 'Authorized')  && $validation){
-                switch ((int)$validationData['x_cod_response']) {
-                    case 1:{
-                        $message = 'AcceptOrder';
-                        if($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled'){
-                            addInvoicePayment(
-                                $invoice['invoiceid'],
-                                $validationData['x_ref_payco'],
-                                $invoice['total'],
-                                null,
-                                $GATEWAY['paymentmethod']
-                            );
-                            logTransaction($GATEWAY['name'], $validationData, "Aceptada");
-                            $results = localAPI($message, $postData, $adminUsername);
-                            $command = "AddInvoicePayment";
-                            $postData = array("gateway" => $GATEWAY["paymentmethod"], "invoiceid" => $mp_transaccion, "amount" => $validationData['x_amount']);
-                            $results = localAPI($command, $postData, $adminUsername);
-                            $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
-                        }else{
-                            if($invoice['status'] == 'Cancelled'){
+                if (($signature == $validationData['x_signature'] || $validationData['x_signature'] == 'Authorized')  && $validation) {
+                    switch ((int)$validationData['x_cod_response']) {
+                        case 1: {
+                                $message = 'AcceptOrder';
+                                if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
+                                    addInvoicePayment(
+                                        $invoice['invoiceid'],
+                                        $validationData['x_ref_payco'],
+                                        $invoice['total'],
+                                        null,
+                                        $GATEWAY['paymentmethod']
+                                    );
+                                    logTransaction($GATEWAY['name'], $validationData, "Aceptada");
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                    // Transaction is recorded in WHMCS (without duplicating payment)
+                                    $command = "AddTransaction";
+                                    $postData = array(
+                                        "userid" => $invoice['userid'],
+                                        "transid" => $validationData['x_ref_payco'],
+                                        "amount" => $validationData['x_amount'],
+                                        "description" => "Pago Epayco - Referencia: " . $validationData['x_ref_payco']
+                                    );
+                                    $results = localAPI($command, $postData, $adminUsername);
+                                } else {
+                                    if ($invoice['status'] == 'Cancelled') {
+
+                                        $productsOrder = Capsule::table('tblinvoiceitems')
+                                            ->select('tblinvoiceitems.description')
+                                            ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra2'])
+                                            ->where('tblinvoiceitems.type', '=', 'Hosting')
+                                            ->get();
+                                        foreach ($productsOrder as $productOrder) {
+                                            $explodProduct = explode(' - ', $productOrder->description, 2);
+                                            $productInfo[] = $explodProduct[0];
+                                        }
+
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty - 1;
+
+                                            if ( $invoice['status'] == 'Cancelled' ||  $invoice['status'] == 'Failed' ) {
+                                                $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                            }
+                                        }
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            $connection = Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+
+                                        $results = localAPI('PendingOrder', $postData, $adminUsername);
+                                        addInvoicePayment(
+                                            $invoice['invoiceid'],
+                                            $validationData['x_ref_payco'],
+                                            $invoice['total'],
+                                            null,
+                                            $GATEWAY['paymentmethod']
+                                        );
+                                        logTransaction($GATEWAY['name'], $validationData, "Aceptada");
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                        $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
+                                        // Transaction is recorded in WHMCS (without duplicating payment)
+                                        $command = "AddTransaction";
+                                        $postData = array(
+                                            "userid" => $invoice['userid'],
+                                            "transid" => $validationData['x_ref_payco'],
+                                            "amount" => $validationData['x_amount'],
+                                            "description" => "Pago Epayco - Referencia: " . $validationData['x_ref_payco']
+                                        );
+                                        $results = localAPI($command, $postData, $adminUsername);
+                                    }
+                                }
+                            }
+                            break;
+                        case 2: {
+                                $message = 'CancelledOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Cancelled");
                                 
-                                $productsOrder = Capsule::table('tblinvoiceitems')
-                                    ->select('tblinvoiceitems.description')
-                                    ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra2'])
-                                    ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                    ->get();
-                                foreach ($productsOrder as $productOrder )
-                                {
-                                    $explodProduct = explode(' - ', $productOrder->description, 2);
-                                    $productInfo[] = $explodProduct[0]; 
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 2: " . $e->getMessage());
                                 }
                                 
-                                $products = Capsule::table('tblproducts')
-                                    ->whereIn('name', $productInfo)
-                                    ->get(['name', 'qty'])
-                                    ->all();
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($command, $postData, $adminUsername);
+                                }
+                            }
+                            break;
+                        case 3: {
+                                $message = 'PendingOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Failure");
                                 
-                                for($i=0; $i<count($products); $i++ ){
-                                    $productData[$i]["name"] = $products[$i]->name;
-                                    $productData[$i]["qty"] =  $products[$i]->qty-1;
-                                } 
-                                 
-                                for($j=0; $j<count($productData); $j++ ){
-                                   $connection = Capsule::table('tblproducts')
-                                    ->where('name',"=", $productData[$j]["name"])
-                                    ->update(['qty'=> $productData[$j]["qty"]]); 
-                                } 
-                
-                                $results = localAPI('PendingOrder', $postData, $adminUsername);
-                                    addInvoicePayment(
-                                    $invoice['invoiceid'],
-                                    $validationData['x_ref_payco'],
-                                    $invoice['total'],
-                                    null,
-                                    $GATEWAY['paymentmethod']
-                                );
-                                 logTransaction($GATEWAY['name'], $validationData, "Aceptada");
-                                $results = localAPI($message, $postData, $adminUsername);
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
-                                $command = "AddInvoicePayment";
-                                $postData = array("gateway" => $GATEWAY["paymentmethod"], "invoiceid" => $mp_transaccion, "amount" => $validationData['x_amount']);
-                                $results = localAPI($command, $postData, $adminUsername);
-                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 3: " . $e->getMessage());
+                                }
+                                
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                }
                             }
-       
-   
-                        }
-                    }break;
-                    case 2:{
-                        $message = 'CancelledOrder';
-                        logTransaction($GATEWAY['name'], $validationData, "Cancelled");
-                        if($invoice['status'] != 'Cancelled'){
-                            $results = localAPI($command, $postData, $adminUsername);
-                        }
-                    }break;
-                    case 3:{
-                        $message = 'PendingOrder';
-                        if($invoice['status'] == 'Cancelled'){
-                            $productsOrder = Capsule::table('tblinvoiceitems')
-                                ->select('tblinvoiceitems.description')
-                                ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra2'])
-                                ->where('tblinvoiceitems.type', '=', 'Hosting')
-                                ->get();
-                            foreach ($productsOrder as $productOrder )
-                            {
-                                $explodProduct = explode(' - ', $productOrder->description, 2);
-                                $productInfo[] = $explodProduct[0]; 
+                            break;
+                        case 4: {
+                                $message = 'PendingOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 4: " . $e->getMessage());
+                                }
+                                
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                }
                             }
-                            
-                            $products = Capsule::table('tblproducts')
-                                ->whereIn('name', $productInfo)
-                                ->get(['name', 'qty'])
-                                ->all();
-                            
-                            for($i=0; $i<count($products); $i++ ){
-                                $productData[$i]["name"] = $products[$i]->name;
-                                $productData[$i]["qty"] =  $products[$i]->qty-1;
-                            } 
-                            
-                            for($j=0; $j<count($productData); $j++ ){
-                               Capsule::table('tblproducts')
-                                ->where('name',"=", $productData[$j]["name"])
-                                ->update(['qty'=> $productData[$j]["qty"]]);
-                            } 
-                        }
-                    }break;
-                    case 4:{
-                        $message = 'PendingOrder';
-                        logTransaction($GATEWAY['name'], $validationData, "Failure");
-                        if($invoice['status'] != 'Cancelled'){
-                            $results = localAPI($command, $postData, $adminUsername);
-                        }
-                    }break;
-                    case 6:{
-                        $message = 'PendingOrder';
-                        logTransaction($GATEWAY['name'], $validationData, "Failure");
-                        if($invoice['status'] != 'Cancelled'){
-                            $results = localAPI($command, $postData, $adminUsername);
-                        }
-                    }break;
-                    case 10:{
-                        $message = 'PendingOrder';
-                        logTransaction($GATEWAY['name'], $validationData, "Failure");
-                        if($invoice['status'] != 'Cancelled'){
-                            $results = localAPI($command, $postData, $adminUsername);
-                        }
-                    }break;
-                    case 11:{
-                        $message = 'PendingOrder';
-                        logTransaction($GATEWAY['name'], $validationData, "Failure");
-                        if($invoice['status'] != 'Cancelled'){
-                            $results = localAPI($command, $postData, $adminUsername);
-                        }
-                    }break;
-                }
-                }else{
+                            break;
+                        case 6: {
+                                $message = 'PendingOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 6: " . $e->getMessage());
+                                }
+                                
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                }
+                            }
+                            break;
+                        case 10: {
+                                $message = 'PendingOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 10: " . $e->getMessage());
+                                }
+                                
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                }
+                            }
+                            break;
+                        case 11: {
+                                $message = 'PendingOrder';
+                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                
+                                try {
+                                    // Restaurar inventario del pedido fallido
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->where('invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    if (!empty($productsOrder)) {
+                                        foreach ($productsOrder as $item) {
+                                            $parts = explode(' - ', $item->description, 2);
+                                            $productName = $parts[0];
+                                            
+                                            Capsule::table('tblproducts')
+                                                ->where('name', '=', $productName)
+                                                ->increment('qty');
+                                        }
+                                    }
+                                } catch (\Exception $e) {
+                                    logActivity("Error restaurando inventario case 11: " . $e->getMessage());
+                                }
+                                
+                                if ($invoice['status'] != 'Cancelled') {
+                                    $results = localAPI($message, $postData, $adminUsername);
+                                }
+                            }
+                            break;
+                    }
+                } else {
                     $message = "Firma no valida";
                 }
-            }
-            else
-            {
+            } else {
                 $message = "UndefinedOrder";
                 //BORRAR PORQUE YA FUE INGRESADA LA TRANSACCION
                 $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->delete();
@@ -776,77 +950,80 @@ class EpaycoConfig
     }
     function epayco_loadCountries()
     {
-        $countriesJsonString = file_get_contents(__DIR__.'/../../resources/country/dist.countries.json');
+        $countriesJsonString = file_get_contents(__DIR__ . '/../../resources/country/dist.countries.json');
         $countriesJson = json_decode($countriesJsonString);
         $countries = array();
-        foreach($countriesJson as $code => $country){
+        foreach ($countriesJson as $code => $country) {
             $countries[$code] = $country->name;
         }
-    
-        if(file_exists(__DIR__.'/../../resources/country/countries.json')){
-            $customCountriesJsonString = file_get_contents(__DIR__.'/../../resources/country/countries.json');
+
+        if (file_exists(__DIR__ . '/../../resources/country/countries.json')) {
+            $customCountriesJsonString = file_get_contents(__DIR__ . '/../../resources/country/countries.json');
             $customCountriesJson = json_decode($customCountriesJsonString);
-            foreach($customCountriesJson as $code => $country){
-    
-                if($country === false){
+            foreach ($customCountriesJson as $code => $country) {
+
+                if ($country === false) {
                     unset($countries[$code]);
                     break;
                 }
-    
+
                 $countries[$code] = $country->name;
             }
         }
-    
+
         return $countries;
     }
-    function ePaycoToken($gateway){
-       $url = "https://apify.epayco.co/login";
-       $data = array(
+    function ePaycoToken($gateway)
+    {
+        $url = "https://apify.epayco.co/login";
+        $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
         );
-      
-        $json =$this->makeRequest($gateway,$data, $url,true);
-        
-        if(is_null($json)) {
-          throw new Exception("Error get bearer_token.");
-        } 
-        
+
+        $json = $this->makeRequest($gateway, $data, $url, true);
+
+        if (is_null($json)) {
+            throw new Exception("Error get bearer_token.");
+        }
+
         $bearer_token = false;
-        if(isset($json->bearer_token)) {
-          $bearer_token=$json->bearer_token;
-        }else if(isset($json->token)){
-          $bearer_token= $json->token;
+        if (isset($json->bearer_token)) {
+            $bearer_token = $json->bearer_token;
+        } else if (isset($json->token)) {
+            $bearer_token = $json->token;
         }
         error_log(json_encode($json));
-        if(!$bearer_token) {
-          $msj = isset($json->message) ? $json->message : "Error get bearer_token";
-          if($msj == "Error get bearer_token" && isset($json->error)){
-              $msj = $json->error;
-          }
-          throw new Exception($msj);
+        if (!$bearer_token) {
+            $msj = isset($json->message) ? $json->message : "Error get bearer_token";
+            if ($msj == "Error get bearer_token" && isset($json->error)) {
+                $msj = $json->error;
+            }
+            throw new Exception($msj);
         }
         return $bearer_token;
     }
-    function epaycoSessionPayment($gateway,$data,$bearer_token){
+    function epaycoSessionPayment($gateway, $data, $bearer_token)
+    {
         $url = "https://apify.epayco.co/payment/session/create";
-        return $this->makeRequest($gateway, $data, $url, "Bearer ".$bearer_token);
+        return $this->makeRequest($gateway, $data, $url, "Bearer " . $bearer_token);
     }
-    function getCustomerIp(){
+    function getCustomerIp()
+    {
         $ipaddress = '';
         if (isset($_SERVER['HTTP_CLIENT_IP']))
             $ipaddress = $_SERVER['HTTP_CLIENT_IP'];
-        else if(isset($_SERVER['HTTP_X_FORWARDED_FOR']))
+        else if (isset($_SERVER['HTTP_X_FORWARDED_FOR']))
             $ipaddress = $_SERVER['HTTP_X_FORWARDED_FOR'];
-        else if(isset($_SERVER['HTTP_X_FORWARDED']))
+        else if (isset($_SERVER['HTTP_X_FORWARDED']))
             $ipaddress = $_SERVER['HTTP_X_FORWARDED'];
-        else if(isset($_SERVER['HTTP_X_CLUSTER_CLIENT_IP']))
+        else if (isset($_SERVER['HTTP_X_CLUSTER_CLIENT_IP']))
             $ipaddress = $_SERVER['HTTP_X_CLUSTER_CLIENT_IP'];
-        else if(isset($_SERVER['HTTP_FORWARDED_FOR']))
+        else if (isset($_SERVER['HTTP_FORWARDED_FOR']))
             $ipaddress = $_SERVER['HTTP_FORWARDED_FOR'];
-        else if(isset($_SERVER['HTTP_FORWARDED']))
+        else if (isset($_SERVER['HTTP_FORWARDED']))
             $ipaddress = $_SERVER['HTTP_FORWARDED'];
-        else if(isset($_SERVER['REMOTE_ADDR']))
+        else if (isset($_SERVER['REMOTE_ADDR']))
             $ipaddress = $_SERVER['REMOTE_ADDR'];
         else
             $ipaddress = 'UNKNOWN';
@@ -854,26 +1031,66 @@ class EpaycoConfig
     }
     function string_sanitize($string, $force_lowercase = true, $anal = false)
     {
-
-        $strip = array("~", "`", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "=", "+", "[", "{", "]", "}", "\\", "|", ";", ":", "\"", "'", "&#8216;", "&#8217;", "&#8220;", "&#8221;", "&#8211;", "&#8212;", "â€”", "â€“", ",", "<", ".", ">", "/", "?");
+        // Convert accented characters to ASCII equivalent
+        if (function_exists('iconv')) {
+            $string = iconv('UTF-8', 'ASCII//TRANSLIT', $string);
+        }
+        
+        $strip = array("~", "`", "!", "@", "#", "$", "%", "^", "&", "*", "(", ")", "_", "=", "+", "[", "{", "]", "}", "\\", "|", ";", ":", "\"", "'", "&#8216;", "&#8217;", "&#8220;", "&#8221;", "&#8211;", "&#8212;", "â€”", "â€“", ",", "<", ".", ">", "/", "?", "-");
         $clean = trim(str_replace($strip, "", strip_tags($string)));
-        $clean = preg_replace('/\s+/', "_", $clean);
+        $clean = preg_replace('/\s+/', ' ', $clean);
         $clean = ($anal) ? preg_replace("/[^a-zA-Z0-9]/", "", $clean) : $clean;
         return $clean;
     }
-    function epayco_getAdminUserWithApiAccess(){
-    try {
-        return Capsule::table('tbladmins')
-            ->join('tbladminroles', 'tbladmins.roleid', '=', 'tbladmins.roleid')
-            ->join('tbladminperms', 'tbladminroles.id', '=', 'tbladminperms.roleid')
-            ->select('tbladmins.username')
-            ->where('tbladmins.disabled', '=', 0)
-            ->where('tbladminperms.permid', '=', 81)
-            ->get();
-    }catch (\Exception $e){
-        logActivity("ePayco Suscriptions Addon error in method ". __FUNCTION__.' in '. __FILE__."(".__LINE__."): ".$e->getMessage());
+    
+    function normalizeDecimalValue($value)
+    {
+        // Remove spaces and trim
+        $value = trim($value);
+        
+        // Remove currency symbols and letters
+        $value = preg_replace('/[^0-9.,]/', '', $value);
+        
+        // Count occurrences of dots and commas
+        $dotCount = substr_count($value, '.');
+        $commaCount = substr_count($value, ',');
+        
+        // Determine the decimal separator based on format
+        if ($dotCount == 0 && $commaCount == 1) {
+            // Format: "1234,56" - comma is decimal separator (European without thousands)
+            $value = str_replace(',', '.', $value);
+        } elseif ($dotCount == 1 && $commaCount == 0) {
+            // Format: "1234.56" - dot is decimal separator (US format)
+            // Keep as is
+        } elseif ($dotCount > 0 && $commaCount == 1) {
+            // Format: "1.234.567,89" - dots are thousand separators, comma is decimal
+            $value = str_replace('.', '', $value);
+            $value = str_replace(',', '.', $value);
+        } elseif ($dotCount > 0 && $commaCount == 0) {
+            // Format: "1.234.567" - dots are thousand separators, no decimal
+            $value = str_replace('.', '', $value);
+        } elseif ($commaCount > 1) {
+            // Format: "1,234,567" - commas are thousand separators (US), no decimal
+            $value = str_replace(',', '', $value);
+        }
+        
+        // Convert to float
+        return floatval($value);
     }
-    return false;
+    
+    function epayco_getAdminUserWithApiAccess()
+    {
+        try {
+            return Capsule::table('tbladmins')
+                ->join('tbladminroles', 'tbladmins.roleid', '=', 'tbladmins.roleid')
+                ->join('tbladminperms', 'tbladminroles.id', '=', 'tbladminperms.roleid')
+                ->select('tbladmins.username')
+                ->where('tbladmins.disabled', '=', 0)
+                ->where('tbladminperms.permid', '=', 81)
+                ->get();
+        } catch (\Exception $e) {
+            logActivity("ePayco Suscriptions Addon error in method " . __FUNCTION__ . ' in ' . __FILE__ . "(" . __LINE__ . "): " . $e->getMessage());
+        }
+        return false;
+    }
 }
-}
-?>

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -26,10 +26,22 @@ class EpaycoConfig
                     $table->dateTime("momento");
                     $table->string("gateway");
                     $table->string("refPayco");
+                    $table->integer("reintentos_count")->default(0);
                 });
                 return true;
             } catch (\Exception $ex) {
                 throw new Exception("No se pudo crear la tabla de transacciones: " . $ex->getMessage());
+            }
+        } else {
+            // Agregar columna si no existe
+            if (!WHMCS\Database\Capsule::schema()->hasColumn($nombreTabla, 'reintentos_count')) {
+                try {
+                    WHMCS\Database\Capsule::schema()->table($nombreTabla, function ($table) {
+                        $table->integer('reintentos_count')->default(0);
+                    });
+                } catch (\Exception $ex) {
+                    // Columna ya existe o error
+                }
             }
         }
         return false;
@@ -230,10 +242,12 @@ class EpaycoConfig
         $address1 = $params['clientdetails']['address1'];
         $returnUrl = $params['returnurl'];
         $billing_name = $firstname . " " . $lastname;
-        
-        // Get store currency from client
-        $clientDetails = localAPI("getclientsdetails", ["clientid" => $params['clientdetails']['userid'], "responsetype" => "json"], $params['WHMCSAdminUser']);
-        $currencyCode = strtolower($clientDetails['currency_code']);
+        if ($params['currencyCode'] == 'default') {
+            $clientDetails = localAPI("getclientsdetails", ["clientid" => $params['clientdetails']['userid'], "responsetype" => "json"], $params['WHMCSAdminUser']);
+            $currencyCode = strtolower($clientDetails['currency_code']);
+        } else {
+            $currencyCode = $params['currencyCode'];
+        }
 
         $testMode = $params['testMode'] == 'on' ? true : false;
 
@@ -374,7 +388,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://epayco-checkout-testing.s3.amazonaws.com/checkout.preprod-v2.js">
+                src="https://checkout.epayco.co/checkout-v2.js">
             </script>
             <script>
                 var bntPagar = document.getElementById("btn_epayco");
@@ -466,7 +480,7 @@ class EpaycoConfig
     {
         $bearer_token = $this->ePaycoToken($gateway);
         $publicKey = $gateway['publicKey'];
-        $url = "https://eks-rest-pagos-service.epayco.io/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
+        $url = "https://secure.payco.co/transaction/response.json?ref_payco=" . $transaccion . "&&public_key=" . $publicKey;
         return $this->makeRequest($gateway, [], $url, "Bearer " . $bearer_token);
     }
     function makeRequest($gateway, $data, $url, $bearerToken = false)
@@ -521,7 +535,7 @@ class EpaycoConfig
             'Authorization: Bearer ' . $bearer_token
         );
 
-        $url = 'https://eks-apify-service.epayco.io/payment/session/create';
+        $url = 'https://apify.epayco.co/payment/session/create';
         $responseData = $this->PostCurl($url, $body, $headers);
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
@@ -550,7 +564,7 @@ class EpaycoConfig
         $data = array(
             'public_key' => $publicKey
         );
-        $url = 'https://eks-apify-service.epayco.io/login';
+        $url = 'https://apify.epayco.co/login';
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
@@ -601,7 +615,8 @@ class EpaycoConfig
         }
     }
 
-    function callbackEpayco($idtrans, $confirmation)
+
+       function callbackEpayco($idtrans, $confirmation)
     {
 
         if ($confirmation) {
@@ -670,8 +685,64 @@ class EpaycoConfig
                 if (($signature == $validationData['x_signature'] || $validationData['x_signature'] == 'Authorized')  && $validation) {
                     switch ((int)$validationData['x_cod_response']) {
                         case 1: {
+                                echo "<pre style='background:green;color:white;'>DEBUG CASE 1 - ACEPTADA</pre>";
+                                var_dump("Entrando case 1");
+                                var_dump("Invoice Status: " . $invoice['status']);
+                                
                                 $message = 'AcceptOrder';
                                 if ($invoice['status'] != 'Paid' && $invoice['status'] != 'Cancelled') {
+                                    // Descontar stock cuando el pago es aceptado
+                                    echo "<pre>DEBUG CASE 1: Procesando descuento de stock</pre>";
+                                    
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
+                                    $productsOrder = Capsule::table('tblinvoiceitems')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
+                                        ->get();
+                                    
+                                    echo "<pre>DEBUG CASE 1: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
+                                    }
+                                    
+                                    echo "<pre>DEBUG CASE 1: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 1: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 1: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty - 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 1: Product Data Array después de restar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightgreen;'>DEBUG CASE 1: Stock descontado exitosamente (1 unidad)</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 1: ProductInfo está vacío - NO HAY PRODUCTOS PARA DESCONTAR STOCK</pre>";
+                                    }
+                                    
                                     addInvoicePayment(
                                         $invoice['invoiceid'],
                                         $validationData['x_ref_payco'],
@@ -693,6 +764,10 @@ class EpaycoConfig
                                 } else {
                                     if ($invoice['status'] == 'Cancelled') {
 
+                                echo "<pre>DEBUG CASE 2 - RECHAZADA: Entrando al case 2.2</pre>";
+                                var_dump("Invoice Status: " . $invoice['status']);
+                                var_dump("Validation Data x_extra1: " . $validationData['x_extra1']);
+                                var_dump("Validation Data x_extra2: " . $validationData['x_extra2']);
                                         $productsOrder = Capsule::table('tblinvoiceitems')
                                             ->select('tblinvoiceitems.description')
                                             ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra2'])
@@ -711,10 +786,6 @@ class EpaycoConfig
                                         for ($i = 0; $i < count($products); $i++) {
                                             $productData[$i]["name"] = $products[$i]->name;
                                             $productData[$i]["qty"] =  $products[$i]->qty - 1;
-
-                                            if ( $invoice['status'] == 'Cancelled' ||  $invoice['status'] == 'Failed' ) {
-                                                $productData[$i]["qty"] =  $products[$i]->qty + 1;
-                                            }
                                         }
 
                                         for ($j = 0; $j < count($productData); $j++) {
@@ -748,182 +819,460 @@ class EpaycoConfig
                             }
                             break;
                         case 2: {
-                                $message = 'CancelledOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Cancelled");
+                                //rechazada - restaurar stock sin duplicar
+                                echo "<pre>DEBUG CASE 2 - RECHAZADA: Verificando duplicados</pre>";
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                var_dump("Transacción existente: " . ($resultado ? "SÍ" : "NO"));
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar si ya fue procesada (momento = 0000-00-00 es la bandera)
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    echo "<pre>DEBUG: Procesando rechazada</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Rechazada");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 2: " . $e->getMessage());
+                                    
+                                    echo "<pre>DEBUG: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightgreen;'>DEBUG: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+                                    
+                                    // Marcar como procesada (sin eliminar, para que no se reinserente)
+                                    echo "<pre>DEBUG: Marcando transacción como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:yellow;'>DEBUG CASE 2: Transacción YA PROCESADA, ignorando</pre>";
                                 }
                                 
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($command, $postData, $adminUsername);
-                                }
+                                $message = 'RechazadaPayment';
                             }
                             break;
                         case 3: {
-                                $message = 'PendingOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                echo "<pre style='background:orange;color:white;'>DEBUG CASE 3 - PENDIENTE</pre>";
+                                var_dump("Entrando case 3");
+                                var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar duplicados
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    //pendiente - restaurar stock
+                                    echo "<pre>DEBUG CASE 3: Procesando pendiente</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG CASE 3: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 3: " . $e->getMessage());
-                                }
-                                
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($message, $postData, $adminUsername);
+                                    
+                                    echo "<pre>DEBUG CASE 3: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 3: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 3: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 3: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightsalmon;'>DEBUG CASE 3: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 3: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+
+                                    if ($invoice['status'] != 'Cancelled') {
+                                        $message = 'PendingOrder';
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                    }
+                                    
+                                    // Marcar como procesada
+                                    echo "<pre>DEBUG CASE 3: Marcando como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:orange;'>DEBUG CASE 3: YA PROCESADA, ignorando</pre>";
                                 }
                             }
                             break;
                         case 4: {
-                                $message = 'PendingOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                echo "<pre style='background:red;color:white;'>DEBUG CASE 4 - FALLIDA</pre>";
+                                var_dump("Entrando case 4");
+                                var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar duplicados
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    //fallida - restaurar stock
+                                    echo "<pre>DEBUG CASE 4: Procesando fallida</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG CASE 4: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 4: " . $e->getMessage());
-                                }
-                                
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($message, $postData, $adminUsername);
+                                    
+                                    echo "<pre>DEBUG CASE 4: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 4: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 4: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 4: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightcoral;'>DEBUG CASE 4: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 4: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+
+                                    if ($invoice['status'] != 'Cancelled') {
+                                        $message = 'PendingOrder';
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                    }
+                                    
+                                    // Marcar como procesada
+                                    echo "<pre>DEBUG CASE 4: Marcando como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:red;'>DEBUG CASE 4: YA PROCESADA, ignorando</pre>";
                                 }
                             }
                             break;
                         case 6: {
-                                $message = 'PendingOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                echo "<pre style='background:purple;color:white;'>DEBUG CASE 6</pre>";
+                                var_dump("Entrando case 6");
+                                var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar duplicados
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    //pendiente - restaurar stock
+                                    echo "<pre>DEBUG CASE 6: Procesando</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG CASE 6: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 6: " . $e->getMessage());
-                                }
-                                
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($message, $postData, $adminUsername);
+                                    
+                                    echo "<pre>DEBUG CASE 6: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 6: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 6: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 6: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightyellow;'>DEBUG CASE 6: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 6: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+
+                                    if ($invoice['status'] != 'Cancelled') {
+                                        $message = 'PendingOrder';
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                    }
+                                    
+                                    // Marcar como procesada
+                                    echo "<pre>DEBUG CASE 6: Marcando como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:purple;'>DEBUG CASE 6: YA PROCESADA, ignorando</pre>";
                                 }
                             }
                             break;
                         case 10: {
-                                $message = 'PendingOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                echo "<pre style='background:navy;color:white;'>DEBUG CASE 10</pre>";
+                                var_dump("Entrando case 10");
+                                var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar duplicados
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    //pendiente - restaurar stock
+                                    echo "<pre>DEBUG CASE 10: Procesando</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG CASE 10: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 10: " . $e->getMessage());
-                                }
-                                
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($message, $postData, $adminUsername);
+                                    
+                                    echo "<pre>DEBUG CASE 10: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 10: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 10: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 10: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightblue;'>DEBUG CASE 10: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 10: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+
+                                    if ($invoice['status'] != 'Cancelled') {
+                                        $message = 'PendingOrder';
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                    }
+                                    
+                                    // Marcar como procesada
+                                    echo "<pre>DEBUG CASE 10: Marcando como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:navy;'>DEBUG CASE 10: YA PROCESADA, ignorando</pre>";
                                 }
                             }
                             break;
                         case 11: {
-                                $message = 'PendingOrder';
-                                logTransaction($GATEWAY['name'], $validationData, "Failure");
+                                echo "<pre style='background:teal;color:white;'>DEBUG CASE 11</pre>";
+                                var_dump("Entrando case 11");
+                                var_dump("Invoice Status: " . $invoice['status']);
                                 
-                                try {
-                                    // Restaurar inventario del pedido fallido
+                                // Verificar duplicados
+                                $resultado = Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->first();
+                                $yaFueProcesada = ($resultado && $resultado->momento === '0000-00-00 00:00:00');
+                                var_dump("Ya fue procesada: " . ($yaFueProcesada ? "SÍ" : "NO"));
+                                
+                                if ($resultado && !$yaFueProcesada) {
+                                    //pendiente - restaurar stock
+                                    echo "<pre>DEBUG CASE 11: Procesando</pre>";
+                                    logTransaction($GATEWAY['name'], $validationData, "Failure");
+
+                                    $productInfo = array();
+                                    $productData = array();
+                                    
                                     $productsOrder = Capsule::table('tblinvoiceitems')
-                                        ->where('invoiceid', '=', $validationData['x_extra1'])
-                                        ->where('type', '=', 'Hosting')
+                                        ->select('tblinvoiceitems.description')
+                                        ->where('tblinvoiceitems.invoiceid', '=', $validationData['x_extra1'])
+                                        ->where('tblinvoiceitems.type', '=', 'Hosting')
                                         ->get();
                                     
-                                    if (!empty($productsOrder)) {
-                                        foreach ($productsOrder as $item) {
-                                            $parts = explode(' - ', $item->description, 2);
-                                            $productName = $parts[0];
-                                            
-                                            Capsule::table('tblproducts')
-                                                ->where('name', '=', $productName)
-                                                ->increment('qty');
-                                        }
+                                    echo "<pre>DEBUG CASE 11: Productos obtenidos</pre>";
+                                    var_dump($productsOrder);
+                                    
+                                    foreach ($productsOrder as $productOrder) {
+                                        $explodProduct = explode(' - ', $productOrder->description, 2);
+                                        $productInfo[] = $explodProduct[0];
                                     }
-                                } catch (\Exception $e) {
-                                    logActivity("Error restaurando inventario case 11: " . $e->getMessage());
-                                }
-                                
-                                if ($invoice['status'] != 'Cancelled') {
-                                    $results = localAPI($message, $postData, $adminUsername);
+                                    
+                                    echo "<pre>DEBUG CASE 11: Product Info Array</pre>";
+                                    var_dump($productInfo);
+                                    
+                                    if (!empty($productInfo)) {
+                                        echo "<pre>DEBUG CASE 11: Entrando al IF de productInfo no vacío</pre>";
+                                        $products = Capsule::table('tblproducts')
+                                            ->whereIn('name', $productInfo)
+                                            ->get(['name', 'qty'])
+                                            ->all();
+
+                                        echo "<pre>DEBUG CASE 11: Productos de DB</pre>";
+                                        var_dump($products);
+
+                                        for ($i = 0; $i < count($products); $i++) {
+                                            $productData[$i]["name"] = $products[$i]->name;
+                                            $productData[$i]["qty"] =  $products[$i]->qty + 1;
+                                        }
+
+                                        echo "<pre>DEBUG CASE 11: Product Data Array después de sumar qty</pre>";
+                                        var_dump($productData);
+
+                                        for ($j = 0; $j < count($productData); $j++) {
+                                            Capsule::table('tblproducts')
+                                                ->where('name', "=", $productData[$j]["name"])
+                                                ->update(['qty' => $productData[$j]["qty"]]);
+                                        }
+                                        
+                                        echo "<pre style='background:lightseagreen;'>DEBUG CASE 11: Stock actualizado exitosamente</pre>";
+                                    } else {
+                                        echo "<pre>DEBUG CASE 11: ProductInfo está vacío - NO HAY PRODUCTOS PARA AUMENTAR STOCK</pre>";
+                                    }
+
+                                    if ($invoice['status'] != 'Cancelled') {
+                                        $message = 'PendingOrder';
+                                        $results = localAPI($message, $postData, $adminUsername);
+                                    }
+                                    
+                                    // Marcar como procesada
+                                    echo "<pre>DEBUG CASE 11: Marcando como procesada</pre>";
+                                    Capsule::table("bapp_epayco")->where("transaccion", "=", $mp_transaccion)->update(['momento' => '0000-00-00 00:00:00']);
+                                } else {
+                                    echo "<pre style='background:teal;'>DEBUG CASE 11: YA PROCESADA, ignorando</pre>";
                                 }
                             }
                             break;
@@ -973,7 +1322,7 @@ class EpaycoConfig
     }
     function ePaycoToken($gateway)
     {
-        $url = "https://eks-apify-service.epayco.io/login";
+        $url = "https://apify.epayco.co/login";
         $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -1003,7 +1352,7 @@ class EpaycoConfig
     }
     function epaycoSessionPayment($gateway, $data, $bearer_token)
     {
-        $url = "https://eks-apify-service.epayco.io/payment/session/create";
+        $url = "https://apify.epayco.co/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer " . $bearer_token);
     }
     function getCustomerIp()

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -535,7 +535,7 @@ class EpaycoConfig
             'Authorization: Bearer ' . $bearer_token
         );
 
-        $url = 'https://apify.epayco.co/payment/session/create';
+        $url = 'https://eks-apify-service.epayco.io/payment/session/create';
         $responseData = $this->PostCurl($url, $body, $headers);
         $jsonData = @json_decode($responseData, true);
         return $jsonData;
@@ -564,7 +564,7 @@ class EpaycoConfig
         $data = array(
             'public_key' => $publicKey
         );
-        $url = 'https://apify.epayco.co/login';
+        $url = 'https://eks-apify-service.epayco.io/login';
         //return $this->epayco_realizar_llamada_api("login", [], $headers);
         $responseData = $this->PostCurl($url, $data, $headers);
         $jsonData = @json_decode($responseData, true);
@@ -1103,7 +1103,7 @@ class EpaycoConfig
     }
     function ePaycoToken($gateway)
     {
-        $url = "https://apify.epayco.co/login";
+        $url = "https://eks-apify-service.epayco.io/login";
         $data = array(
             'public_key' => $gateway['publicKey'],
             'private_key' => $gateway['privateKey']
@@ -1133,7 +1133,7 @@ class EpaycoConfig
     }
     function epaycoSessionPayment($gateway, $data, $bearer_token)
     {
-        $url = "https://apify.epayco.co/payment/session/create";
+        $url = "https://eks-apify-service.epayco.io/payment/session/create";
         return $this->makeRequest($gateway, $data, $url, "Bearer " . $bearer_token);
     }
     function getCustomerIp()

--- a/payco_whmcs/modules/gateways/epayco/epayco.php
+++ b/payco_whmcs/modules/gateways/epayco/epayco.php
@@ -376,7 +376,7 @@ class EpaycoConfig
                 </center> 
             </p>
             <script
-                src="https://checkout.epayco.co/checkout-v2.js">
+                src="https://epayco-checkout-testing.s3.amazonaws.com/checkout.preprod-v2.js">
             </script>
             <script>
                 var bntPagar = document.getElementById("btn_epayco");

--- a/payco_whmcs/modules/gateways/epayco/response.php
+++ b/payco_whmcs/modules/gateways/epayco/response.php
@@ -101,7 +101,7 @@ echo sprintf('
       var inicio_ = document.getElementById("inicio");
       inicio_.href = inicio;
       var ref_payco = getQueryParam("ref_payco");
-      var urlapp = "https://eks-checkout-service.epayco.io/validation/v1/reference/" + ref_payco;
+      var urlapp = "https://secure.epayco.co/validation/v1/reference/" + ref_payco;
 
       $.get(urlapp, function(response) {
         if (response.success) {

--- a/payco_whmcs/modules/gateways/epayco/response.php
+++ b/payco_whmcs/modules/gateways/epayco/response.php
@@ -101,7 +101,7 @@ echo sprintf('
       var inicio_ = document.getElementById("inicio");
       inicio_.href = inicio;
       var ref_payco = getQueryParam("ref_payco");
-      var urlapp = "https://secure.epayco.co/validation/v1/reference/" + ref_payco;
+      var urlapp = "https://eks-checkout-service.epayco.io/validation/v1/reference/" + ref_payco;
 
       $.get(urlapp, function(response) {
         if (response.success) {

--- a/payco_whmcs/modules/gateways/epayco/response.php
+++ b/payco_whmcs/modules/gateways/epayco/response.php
@@ -102,7 +102,7 @@ echo sprintf('
       inicio_.href = inicio;
       var ref_payco = getQueryParam("ref_payco");
       var urlapp = "https://eks-checkout-service.epayco.io/validation/v1/reference/" + ref_payco;
-
+      
       $.get(urlapp, function(response) {
         if (response.success) {
           if (response.data.x_cod_response == 1) {


### PR DESCRIPTION
# Pull Request Documentation and Changes
## Documentation of the Required Changes
- Document the changes required for deployment.
- Properly document each of the requirements.
- Include project dependencies if deemed necessary.
- Maintain this standard to comply with company requirements.
---
## Project Details
### Cells
- **Plugin and SDKs**
### Developers
- **Juan Esteban García Valencia**
### Tickets
- [SDK-1194](https://epayco.atlassian.net/browse/SDK-1194)
- [SDK-1198](https://epayco.atlassian.net/browse/SDK-1198)
### Features
- **BUG** **PRODUCTION**


MEJORAS DEL PR

Inventario (según estado de la transacción)
Aceptado -> Reduce inventario
Fallida -> Restaura inventario
Pendiente -> Restaura inventario
Cancelada -> Restaura inventario
Rechazada -> Restaura inventario
Abandonada -> Restaura inventario
Reintento de pago -> Restaura inventario antes de generar nueva transacción

Prevención de pagos duplicados
Validación de transaction_id único
Se ignoran callbacks repetidos (idempotencia)
No se duplica el registro del pago ni el movimiento de inventario

Sanitización de datos enviados
Se limita la longitud del nombre del producto
Se limita la longitud de la descripción
Se eliminan caracteres inválidos y HTML

Manejo de moneda
Se oculta la opción de moneda en configuración
La moneda se toma únicamente desde la factura

Formato de valores
Normalización a 2 decimales exactos
Sin separadores de miles
Compatible con validaciones de la pasarela

Errores en checkout
Se muestran errores de sesión al usuario
Evita recargas silenciosas
Facilita diagnóstico de fallos


[SDK-1194]: https://epayco.atlassian.net/browse/SDK-1194?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SDK-1198]: https://epayco.atlassian.net/browse/SDK-1198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ